### PR TITLE
Ensure error estimate values are positive

### DIFF
--- a/c/cukf.cpp
+++ b/c/cukf.cpp
@@ -178,7 +178,7 @@ void ukf_get_state_error(real_t state_error[UKF_STATE_DIM]) {
     Eigen::Map< Eigen::Matrix<real_t, UKF_STATE_DIM, 1> > error_map =
         Eigen::Map< Eigen::Matrix<real_t, UKF_STATE_DIM, 1>
             >(state_error);
-    error_map = ukf.get_state_covariance().rowwise().sum().sqrt();
+    error_map = ukf.get_state_covariance().cwiseAbs().rowwise().sum().sqrt();
 }
 
 void ukf_sensor_clear() {

--- a/ccs-c66x/cukf.c
+++ b/ccs-c66x/cukf.c
@@ -817,7 +817,7 @@ void ukf_get_state_error(real_t in[UKF_STATE_DIM]) {
 
         #pragma MUST_ITERATE(24, 24)
         for (j = 0; j < UKF_STATE_DIM; j++) {
-            in[i] += state_covariance[i*UKF_STATE_DIM + j];
+            in[i] += absval(state_covariance[i*UKF_STATE_DIM + j]);
         }
 
         in[i] = fsqrt(in[i]);


### PR DESCRIPTION
This should really be calculated based on the inverse of the covariance matrix, but the current approach is conservative.
