### PR TITLE
Add support for 2-DOF field vectors in measurement model

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -31,6 +31,8 @@ INCLUDE_DIRECTORIES(${googlebenchmark_dir}/include ../include ${eigen_dir})
 ADD_EXECUTABLE(benchmark
     StateVectorBenchmark.cpp
     MeasurementVectorBenchmark.cpp
+    CoreBenchmark.cpp
+    SquareRootCoreBenchmark.cpp
     BenchmarkMain.cpp)
 
 # Create dependency of benchmark on googlebenchmark

--- a/benchmark/CoreBenchmark.cpp
+++ b/benchmark/CoreBenchmark.cpp
@@ -69,7 +69,7 @@ using MyMeasurementVector = UKF::DynamicMeasurementVector<
     UKF::Field<GPS_Position, UKF::Vector<3>>,
     UKF::Field<GPS_Velocity, UKF::Vector<3>>,
     UKF::Field<Accelerometer, UKF::Vector<3>>,
-    UKF::Field<Magnetometer, UKF::Vector<3>>,
+    UKF::Field<Magnetometer, UKF::FieldVector>,
     UKF::Field<Gyroscope, UKF::Vector<3>>
 >;
 
@@ -102,9 +102,9 @@ UKF::Vector<3> MyMeasurementVector::expected_measurement
 }
 
 template <> template <>
-UKF::Vector<3> MyMeasurementVector::expected_measurement
+UKF::FieldVector MyMeasurementVector::expected_measurement
 <MyStateVector, Magnetometer>(const MyStateVector& state) {
-    return state.get_field<Attitude>() * UKF::Vector<3>(1, 0, 0);
+    return state.get_field<Attitude>() * UKF::FieldVector(1, 0, 0);
 }
 
 template <> template <>
@@ -165,7 +165,7 @@ void Core_InnovationStep(benchmark::State& state) {
     m.set_field<GPS_Position>(UKF::Vector<3>(100, 10, -50));
     m.set_field<GPS_Velocity>(UKF::Vector<3>(20, 0, 0));
     m.set_field<Accelerometer>(UKF::Vector<3>(0, 0, -9.8));
-    m.set_field<Magnetometer>(UKF::Vector<3>(0, -1, 0));
+    m.set_field<Magnetometer>(UKF::FieldVector(0, -1, 0));
     m.set_field<Gyroscope>(UKF::Vector<3>(0.5, 0, 0));
 
     test_filter.a_priori_step(0.01);
@@ -184,7 +184,7 @@ void Core_APosterioriStep(benchmark::State& state) {
     m.set_field<GPS_Position>(UKF::Vector<3>(100, 10, -50));
     m.set_field<GPS_Velocity>(UKF::Vector<3>(20, 0, 0));
     m.set_field<Accelerometer>(UKF::Vector<3>(0, 0, -9.8));
-    m.set_field<Magnetometer>(UKF::Vector<3>(0, -1, 0));
+    m.set_field<Magnetometer>(UKF::FieldVector(0, -1, 0));
     m.set_field<Gyroscope>(UKF::Vector<3>(0.5, 0, 0));
 
     test_filter.a_priori_step(0.01);

--- a/benchmark/CoreBenchmark.cpp
+++ b/benchmark/CoreBenchmark.cpp
@@ -1,0 +1,203 @@
+#include <benchmark/benchmark.h>
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+#include "UKF/Types.h"
+#include "UKF/Integrator.h"
+#include "UKF/StateVector.h"
+#include "UKF/MeasurementVector.h"
+#include "UKF/Core.h"
+
+enum MyStateFields {
+    Position,
+    Velocity,
+    Attitude,
+    AngularVelocity
+};
+
+using MyStateVector = UKF::StateVector<
+    UKF::Field<Position, UKF::Vector<3>>,
+    UKF::Field<Velocity, UKF::Vector<3>>,
+    UKF::Field<Attitude, UKF::Quaternion>,
+    UKF::Field<AngularVelocity, UKF::Vector<3>>
+>;
+
+template <> constexpr real_t UKF::Parameters::AlphaSquared<MyStateVector> = 1e-6;
+
+/*
+State vector process model. One version takes body frame kinematic
+acceleration and angular acceleration as inputs, the other doesn't (assumes
+zero accelerations).
+*/
+template <> template <>
+MyStateVector MyStateVector::derivative<UKF::Vector<3>, UKF::Vector<3>>(
+        const UKF::Vector<3>& acceleration, const UKF::Vector<3>& angular_acceleration) const {
+    MyStateVector temp;
+    
+    /* Position derivative. */
+    temp.set_field<Position>(get_field<Velocity>());
+
+    /* Velocity derivative. */
+    temp.set_field<Velocity>(get_field<Attitude>().conjugate() * acceleration);
+
+    /* Attitude derivative. */
+    UKF::Quaternion temp_q;
+    temp_q.vec() = get_field<AngularVelocity>();
+    temp_q.w() = 0;
+    temp.set_field<Attitude>(temp_q);
+
+    /* Angular velocity derivative. */
+    temp.set_field<AngularVelocity>(angular_acceleration);
+
+    return temp;
+}
+
+template <> template <>
+MyStateVector MyStateVector::derivative<>() const {
+    return derivative(UKF::Vector<3>(0, 0, 0), UKF::Vector<3>(0, 0, 0));
+}
+
+/* Set up measurement vector class. */
+enum MyMeasurementFields {
+    GPS_Position,
+    GPS_Velocity,
+    Accelerometer,
+    Magnetometer,
+    Gyroscope
+};
+
+using MyMeasurementVector = UKF::DynamicMeasurementVector<
+    UKF::Field<GPS_Position, UKF::Vector<3>>,
+    UKF::Field<GPS_Velocity, UKF::Vector<3>>,
+    UKF::Field<Accelerometer, UKF::Vector<3>>,
+    UKF::Field<Magnetometer, UKF::Vector<3>>,
+    UKF::Field<Gyroscope, UKF::Vector<3>>
+>;
+
+using MyCore = UKF::Core<
+    MyStateVector,
+    MyMeasurementVector,
+    UKF::IntegratorRK4
+>;
+
+/*
+Define measurement model to be used in tests. NOTE: These are just for
+testing, don't expect them to make any physical sense whatsoever.
+*/
+template <> template <>
+UKF::Vector<3> MyMeasurementVector::expected_measurement
+<MyStateVector, GPS_Position>(const MyStateVector& state) {
+    return state.get_field<Position>();
+}
+
+template <> template <>
+UKF::Vector<3> MyMeasurementVector::expected_measurement
+<MyStateVector, GPS_Velocity>(const MyStateVector& state) {
+    return state.get_field<Velocity>();
+}
+
+template <> template <>
+UKF::Vector<3> MyMeasurementVector::expected_measurement
+<MyStateVector, Accelerometer>(const MyStateVector& state) {
+    return state.get_field<Attitude>() * UKF::Vector<3>(0, 0, -9.8);
+}
+
+template <> template <>
+UKF::Vector<3> MyMeasurementVector::expected_measurement
+<MyStateVector, Magnetometer>(const MyStateVector& state) {
+    return state.get_field<Attitude>() * UKF::Vector<3>(1, 0, 0);
+}
+
+template <> template <>
+UKF::Vector<3> MyMeasurementVector::expected_measurement
+<MyStateVector, Gyroscope>(const MyStateVector& state) {
+    return state.get_field<AngularVelocity>();
+}
+
+/* Set the measurement covariance vector. */
+template <>
+MyMeasurementVector::CovarianceVector MyMeasurementVector::measurement_covariance =
+    MyMeasurementVector::CovarianceVector();
+
+MyCore create_initialised_test_filter() {
+    MyMeasurementVector::measurement_covariance << 10, 10, 10, 1, 1, 1, 5e-1, 5e-1, 5e-1, 5e-1, 5e-1, 5e-1, 0.05, 0.05, 0.05;
+    MyCore test_filter;
+    test_filter.state.set_field<Position>(UKF::Vector<3>(0, 0, 0));
+    test_filter.state.set_field<Velocity>(UKF::Vector<3>(0, 0, 0));
+    test_filter.state.set_field<Attitude>(UKF::Quaternion(1, 0, 0, 0));
+    test_filter.state.set_field<AngularVelocity>(UKF::Vector<3>(0, 0, 0));
+    test_filter.covariance = MyStateVector::CovarianceMatrix::Zero();
+    test_filter.covariance.diagonal() << 10000, 10000, 10000, 100, 100, 100, 1, 1, 5, 10, 10, 10;
+
+    real_t a, b;
+    real_t dt = 0.01;
+    a = std::sqrt(0.1*dt*dt);
+    b = std::sqrt(0.1*dt);
+    test_filter.process_noise_covariance << a, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                            0, a, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                            0, 0, a, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                            0, 0, 0, b, 0, 0, 0, 0, 0, 0, 0, 0,
+                                            0, 0, 0, 0, b, 0, 0, 0, 0, 0, 0, 0,
+                                            0, 0, 0, 0, 0, b, 0, 0, 0, 0, 0, 0,
+                                            0, 0, 0, 0, 0, 0, a, 0, 0, 0, 0, 0,
+                                            0, 0, 0, 0, 0, 0, 0, a, 0, 0, 0, 0,
+                                            0, 0, 0, 0, 0, 0, 0, 0, a, 0, 0, 0,
+                                            0, 0, 0, 0, 0, 0, 0, 0, 0, b, 0, 0,
+                                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, b, 0,
+                                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, b;
+
+    return test_filter;
+}
+
+void Core_APrioriStep(benchmark::State& state) {
+    MyCore test_filter = create_initialised_test_filter();
+
+    while(state.KeepRunning()) {
+        test_filter.a_priori_step(0.01);
+    }
+}
+
+BENCHMARK(Core_APrioriStep);
+
+void Core_InnovationStep(benchmark::State& state) {
+    MyCore test_filter = create_initialised_test_filter();
+    MyMeasurementVector m;
+
+    m.set_field<GPS_Position>(UKF::Vector<3>(100, 10, -50));
+    m.set_field<GPS_Velocity>(UKF::Vector<3>(20, 0, 0));
+    m.set_field<Accelerometer>(UKF::Vector<3>(0, 0, -9.8));
+    m.set_field<Magnetometer>(UKF::Vector<3>(0, -1, 0));
+    m.set_field<Gyroscope>(UKF::Vector<3>(0.5, 0, 0));
+
+    test_filter.a_priori_step(0.01);
+
+    while(state.KeepRunning()) {
+        test_filter.innovation_step(m);
+    }
+}
+
+BENCHMARK(Core_InnovationStep);
+
+void Core_APosterioriStep(benchmark::State& state) {
+    MyCore test_filter = create_initialised_test_filter();
+    MyMeasurementVector m;
+
+    m.set_field<GPS_Position>(UKF::Vector<3>(100, 10, -50));
+    m.set_field<GPS_Velocity>(UKF::Vector<3>(20, 0, 0));
+    m.set_field<Accelerometer>(UKF::Vector<3>(0, 0, -9.8));
+    m.set_field<Magnetometer>(UKF::Vector<3>(0, -1, 0));
+    m.set_field<Gyroscope>(UKF::Vector<3>(0.5, 0, 0));
+
+    test_filter.a_priori_step(0.01);
+    test_filter.innovation_step(m);
+
+    MyStateVector::CovarianceMatrix initial_cov = test_filter.covariance;
+    MyStateVector initial_state = test_filter.state;
+
+    while(state.KeepRunning()) {
+        test_filter.covariance = initial_cov;
+        test_filter.state = initial_state;
+        test_filter.a_posteriori_step();
+    }
+}
+
+BENCHMARK(Core_APosterioriStep);

--- a/benchmark/MeasurementVectorBenchmark.cpp
+++ b/benchmark/MeasurementVectorBenchmark.cpp
@@ -235,15 +235,20 @@ BENCHMARK(MeasurementVectorDynamic_FullMeasurementCalculation);
 template <> MV_Fixed::CovarianceVector MV_Fixed::measurement_covariance = MV_Fixed::CovarianceVector();
 
 void MeasurementVectorFixed_MeasurementCovariance(benchmark::State& state) {
-    MV_Fixed test_measurement;
+    MV_Fixed test_measurement, expected_measurement;
 
     MV_Fixed::measurement_covariance.set_field<Accelerometer>(UKF::Vector<3>(1, 2, 3));
     MV_Fixed::measurement_covariance.set_field<Gyroscope>(UKF::Vector<3>(4, 5, 6));
     MV_Fixed::measurement_covariance.set_field<StaticPressure>(7);
     MV_Fixed::measurement_covariance.set_field<DynamicPressure>(8);
 
+    expected_measurement.set_field<Accelerometer>(UKF::Vector<3>(1, 2, 3));
+    expected_measurement.set_field<Gyroscope>(UKF::Vector<3>(4, 5, 6));
+    expected_measurement.set_field<StaticPressure>(7);
+    expected_measurement.set_field<DynamicPressure>(8);
+
     while(state.KeepRunning()) {
-        benchmark::DoNotOptimize(test_measurement.calculate_measurement_covariance());
+        benchmark::DoNotOptimize(test_measurement.calculate_measurement_covariance(expected_measurement));
     }
 }
 
@@ -252,15 +257,20 @@ BENCHMARK(MeasurementVectorFixed_MeasurementCovariance);
 template <> MV_Dynamic::CovarianceVector MV_Dynamic::measurement_covariance = MV_Dynamic::CovarianceVector();
 
 void MeasurementVectorDynamic_MeasurementCovariance(benchmark::State& state) {
-    MV_Dynamic test_measurement;
+    MV_Dynamic test_measurement, expected_measurement;
 
     MV_Dynamic::measurement_covariance.set_field<Accelerometer>(UKF::Vector<3>(1, 2, 3));
     MV_Dynamic::measurement_covariance.set_field<Gyroscope>(UKF::Vector<3>(4, 5, 6));
     MV_Dynamic::measurement_covariance.set_field<StaticPressure>(7);
     MV_Dynamic::measurement_covariance.set_field<DynamicPressure>(8);
 
+    expected_measurement.set_field<Accelerometer>(UKF::Vector<3>(1, 2, 3));
+    expected_measurement.set_field<Gyroscope>(UKF::Vector<3>(4, 5, 6));
+    expected_measurement.set_field<StaticPressure>(7);
+    expected_measurement.set_field<DynamicPressure>(8);
+
     while(state.KeepRunning()) {
-        benchmark::DoNotOptimize(test_measurement.calculate_measurement_covariance());
+        benchmark::DoNotOptimize(test_measurement.calculate_measurement_covariance(expected_measurement));
     }
 }
 

--- a/benchmark/SquareRootCoreBenchmark.cpp
+++ b/benchmark/SquareRootCoreBenchmark.cpp
@@ -76,7 +76,7 @@ using MyMeasurementVector = UKF::DynamicMeasurementVector<
     UKF::Field<GPS_Position, UKF::Vector<3>>,
     UKF::Field<GPS_Velocity, UKF::Vector<3>>,
     UKF::Field<Accelerometer, UKF::Vector<3>>,
-    UKF::Field<Magnetometer, UKF::Vector<3>>,
+    UKF::Field<Magnetometer, UKF::FieldVector>,
     UKF::Field<Gyroscope, UKF::Vector<3>>
 >;
 
@@ -109,9 +109,9 @@ UKF::Vector<3> MyMeasurementVector::expected_measurement
 }
 
 template <> template <>
-UKF::Vector<3> MyMeasurementVector::expected_measurement
+UKF::FieldVector MyMeasurementVector::expected_measurement
 <MyStateVector, Magnetometer>(const MyStateVector& state) {
-    return state.get_field<Attitude>() * UKF::Vector<3>(1, 0, 0);
+    return state.get_field<Attitude>() * UKF::FieldVector(1, 0, 0);
 }
 
 template <> template <>
@@ -180,7 +180,7 @@ void SquareRootCore_InnovationStep(benchmark::State& state) {
     m.set_field<GPS_Position>(UKF::Vector<3>(100, 10, -50));
     m.set_field<GPS_Velocity>(UKF::Vector<3>(20, 0, 0));
     m.set_field<Accelerometer>(UKF::Vector<3>(0, 0, -9.8));
-    m.set_field<Magnetometer>(UKF::Vector<3>(0, -1, 0));
+    m.set_field<Magnetometer>(UKF::FieldVector(0, -1, 0));
     m.set_field<Gyroscope>(UKF::Vector<3>(0.5, 0, 0));
 
     test_filter.a_priori_step(0.01);
@@ -199,7 +199,7 @@ void SquareRootCore_APosterioriStep(benchmark::State& state) {
     m.set_field<GPS_Position>(UKF::Vector<3>(100, 10, -50));
     m.set_field<GPS_Velocity>(UKF::Vector<3>(20, 0, 0));
     m.set_field<Accelerometer>(UKF::Vector<3>(0, 0, -9.8));
-    m.set_field<Magnetometer>(UKF::Vector<3>(0, -1, 0));
+    m.set_field<Magnetometer>(UKF::FieldVector(0, -1, 0));
     m.set_field<Gyroscope>(UKF::Vector<3>(0.5, 0, 0));
 
     test_filter.a_priori_step(0.01);

--- a/benchmark/SquareRootCoreBenchmark.cpp
+++ b/benchmark/SquareRootCoreBenchmark.cpp
@@ -1,0 +1,218 @@
+#include <benchmark/benchmark.h>
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+#include "UKF/Types.h"
+#include "UKF/Integrator.h"
+#include "UKF/StateVector.h"
+#include "UKF/MeasurementVector.h"
+#include "UKF/Core.h"
+
+/*
+Set up state vector class. The order of these is changed to prevent
+linker collisions with the ones in CoreBenchmark.cpp.
+*/
+enum MyStateFields {
+    Attitude,
+    AngularVelocity,
+    Position,
+    Velocity
+};
+
+using MyStateVector = UKF::StateVector<
+    UKF::Field<Position, UKF::Vector<3>>,
+    UKF::Field<Velocity, UKF::Vector<3>>,
+    UKF::Field<Attitude, UKF::Quaternion>,
+    UKF::Field<AngularVelocity, UKF::Vector<3>>
+>;
+
+template <> constexpr real_t UKF::Parameters::AlphaSquared<MyStateVector> = 1e-6;
+
+/*
+State vector process model. One version takes body frame kinematic
+acceleration and angular acceleration as inputs, the other doesn't (assumes
+zero accelerations).
+*/
+template <> template <>
+MyStateVector MyStateVector::derivative<UKF::Vector<3>, UKF::Vector<3>>(
+        const UKF::Vector<3>& acceleration, const UKF::Vector<3>& angular_acceleration) const {
+    MyStateVector temp;
+    
+    /* Position derivative. */
+    temp.set_field<Position>(get_field<Velocity>());
+
+    /* Velocity derivative. */
+    temp.set_field<Velocity>(get_field<Attitude>().conjugate() * acceleration);
+
+    /* Attitude derivative. */
+    UKF::Quaternion temp_q;
+    temp_q.vec() = get_field<AngularVelocity>();
+    temp_q.w() = 0;
+    temp.set_field<Attitude>(temp_q);
+
+    /* Angular velocity derivative. */
+    temp.set_field<AngularVelocity>(angular_acceleration);
+
+    return temp;
+}
+
+template <> template <>
+MyStateVector MyStateVector::derivative<>() const {
+    return derivative(UKF::Vector<3>(0, 0, 0), UKF::Vector<3>(0, 0, 0));
+}
+
+/*
+Set up measurement vector class. The order of these is changed to prevent
+linker collisions with the ones in CoreBenchmark.cpp.
+*/
+enum MyMeasurementFields {
+    Accelerometer,
+    Magnetometer,
+    Gyroscope,
+    GPS_Position,
+    GPS_Velocity
+};
+
+using MyMeasurementVector = UKF::DynamicMeasurementVector<
+    UKF::Field<GPS_Position, UKF::Vector<3>>,
+    UKF::Field<GPS_Velocity, UKF::Vector<3>>,
+    UKF::Field<Accelerometer, UKF::Vector<3>>,
+    UKF::Field<Magnetometer, UKF::Vector<3>>,
+    UKF::Field<Gyroscope, UKF::Vector<3>>
+>;
+
+using MyCore = UKF::SquareRootCore<
+    MyStateVector,
+    MyMeasurementVector,
+    UKF::IntegratorRK4
+>;
+
+/*
+Define measurement model to be used in tests. NOTE: These are just for
+testing, don't expect them to make any physical sense whatsoever.
+*/
+template <> template <>
+UKF::Vector<3> MyMeasurementVector::expected_measurement
+<MyStateVector, GPS_Position>(const MyStateVector& state) {
+    return state.get_field<Position>();
+}
+
+template <> template <>
+UKF::Vector<3> MyMeasurementVector::expected_measurement
+<MyStateVector, GPS_Velocity>(const MyStateVector& state) {
+    return state.get_field<Velocity>();
+}
+
+template <> template <>
+UKF::Vector<3> MyMeasurementVector::expected_measurement
+<MyStateVector, Accelerometer>(const MyStateVector& state) {
+    return state.get_field<Attitude>() * UKF::Vector<3>(0, 0, -9.8);
+}
+
+template <> template <>
+UKF::Vector<3> MyMeasurementVector::expected_measurement
+<MyStateVector, Magnetometer>(const MyStateVector& state) {
+    return state.get_field<Attitude>() * UKF::Vector<3>(1, 0, 0);
+}
+
+template <> template <>
+UKF::Vector<3> MyMeasurementVector::expected_measurement
+<MyStateVector, Gyroscope>(const MyStateVector& state) {
+    return state.get_field<AngularVelocity>();
+}
+
+/* Set the measurement covariance vector. */
+template <>
+MyMeasurementVector::CovarianceVector MyMeasurementVector::measurement_root_covariance =
+    MyMeasurementVector::CovarianceVector();
+
+/*
+Initialise covariances as square roots to be comparable with CoreBenchmark.cpp.
+*/
+MyCore create_initialised_sr_test_filter() {
+    MyMeasurementVector::measurement_root_covariance << 
+        10, 10, 10, 1, 1, 1, 5e-1, 5e-1, 5e-1, 5e-1, 5e-1, 5e-1, 0.05, 0.05, 0.05;
+    MyMeasurementVector::measurement_root_covariance = MyMeasurementVector::measurement_root_covariance.array().sqrt();
+    MyCore test_filter;
+    test_filter.state.set_field<Position>(UKF::Vector<3>(0, 0, 0));
+    test_filter.state.set_field<Velocity>(UKF::Vector<3>(0, 0, 0));
+    test_filter.state.set_field<Attitude>(UKF::Quaternion(1, 0, 0, 0));
+    test_filter.state.set_field<AngularVelocity>(UKF::Vector<3>(0, 0, 0));
+    test_filter.root_covariance = MyStateVector::CovarianceMatrix::Zero();
+    test_filter.root_covariance.diagonal() <<
+        10000, 10000, 10000, 100, 100, 100, 1, 1, 5, 10, 10, 10;
+    test_filter.root_covariance = test_filter.root_covariance.llt().matrixU();
+
+    real_t a, b;
+    real_t dt = 0.01;
+    a = std::sqrt(0.1*dt*dt);
+    b = std::sqrt(0.1*dt);
+    test_filter.process_noise_root_covariance << a, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                                 0, a, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                                 0, 0, a, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                                 0, 0, 0, b, 0, 0, 0, 0, 0, 0, 0, 0,
+                                                 0, 0, 0, 0, b, 0, 0, 0, 0, 0, 0, 0,
+                                                 0, 0, 0, 0, 0, b, 0, 0, 0, 0, 0, 0,
+                                                 0, 0, 0, 0, 0, 0, a, 0, 0, 0, 0, 0,
+                                                 0, 0, 0, 0, 0, 0, 0, a, 0, 0, 0, 0,
+                                                 0, 0, 0, 0, 0, 0, 0, 0, a, 0, 0, 0,
+                                                 0, 0, 0, 0, 0, 0, 0, 0, 0, b, 0, 0,
+                                                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, b, 0,
+                                                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, b;
+    test_filter.process_noise_root_covariance = test_filter.process_noise_root_covariance.llt().matrixU();
+
+    return test_filter;
+}
+
+void SquareRootCore_APrioriStep(benchmark::State& state) {
+    MyCore test_filter = create_initialised_sr_test_filter();
+
+    while(state.KeepRunning()) {
+        test_filter.a_priori_step(0.01);
+    }
+}
+
+BENCHMARK(SquareRootCore_APrioriStep);
+
+void SquareRootCore_InnovationStep(benchmark::State& state) {
+    MyCore test_filter = create_initialised_sr_test_filter();
+    MyMeasurementVector m;
+
+    m.set_field<GPS_Position>(UKF::Vector<3>(100, 10, -50));
+    m.set_field<GPS_Velocity>(UKF::Vector<3>(20, 0, 0));
+    m.set_field<Accelerometer>(UKF::Vector<3>(0, 0, -9.8));
+    m.set_field<Magnetometer>(UKF::Vector<3>(0, -1, 0));
+    m.set_field<Gyroscope>(UKF::Vector<3>(0.5, 0, 0));
+
+    test_filter.a_priori_step(0.01);
+
+    while(state.KeepRunning()) {
+        test_filter.innovation_step(m);
+    }
+}
+
+BENCHMARK(SquareRootCore_InnovationStep);
+
+void SquareRootCore_APosterioriStep(benchmark::State& state) {
+    MyCore test_filter = create_initialised_sr_test_filter();
+    MyMeasurementVector m;
+
+    m.set_field<GPS_Position>(UKF::Vector<3>(100, 10, -50));
+    m.set_field<GPS_Velocity>(UKF::Vector<3>(20, 0, 0));
+    m.set_field<Accelerometer>(UKF::Vector<3>(0, 0, -9.8));
+    m.set_field<Magnetometer>(UKF::Vector<3>(0, -1, 0));
+    m.set_field<Gyroscope>(UKF::Vector<3>(0.5, 0, 0));
+
+    test_filter.a_priori_step(0.01);
+    test_filter.innovation_step(m);
+
+    MyStateVector::CovarianceMatrix initial_cov = test_filter.root_covariance;
+    MyStateVector initial_state = test_filter.state;
+
+    while(state.KeepRunning()) {
+        test_filter.root_covariance = initial_cov;
+        test_filter.state = initial_state;
+        test_filter.a_posteriori_step();
+    }
+}
+
+BENCHMARK(SquareRootCore_APosterioriStep);

--- a/examples/ahrs/ahrs.cpp
+++ b/examples/ahrs/ahrs.cpp
@@ -376,7 +376,7 @@ void ukf_iterate(float dt) {
             The time delta is not used by the parameter estimation filter, so
             there's no need to adjust it.
             */
-            ahrs_errors.a_priori_step(dt);
+            ahrs_errors.a_priori_step();
             ahrs_errors.innovation_step(meas, ahrs.state);
             break;
         case 1:

--- a/include/UKF/Core.h
+++ b/include/UKF/Core.h
@@ -165,9 +165,13 @@ public:
 
         /*
         Calculate the Kalman gain as described in equation 72 from the Kraft
-        paper.
+        paper, with a slight change in that we're using a column-pivoting QR
+        decomposition to calculate the Moore-Penrose pseudoinverse rather than
+        the inverse. This allows the innovation covariance to be positive semi-
+        definite.
         */
-        CrossCorrelation kalman_gain = cross_correlation * innovation_covariance.inverse();
+        CrossCorrelation kalman_gain = cross_correlation * innovation_covariance.colPivHouseholderQr().solve(
+            MeasurementVectorType::CovarianceMatrix::Identity(innovation.size(), innovation.size()));
 
         /*
         Calculate the update delta vector, to be applied to the a priori

--- a/include/UKF/Core.h
+++ b/include/UKF/Core.h
@@ -441,8 +441,8 @@ public:
 
     /* Top-level function used to carry out a filter step. */
     template <typename... U>
-    void step(real_t delta, const MeasurementVectorType& z, const U&... input) {
-        a_priori_step(delta);
+    void step(const MeasurementVectorType& z, const U&... input) {
+        a_priori_step();
         innovation_step(z, input...);
         a_posteriori_step();
     }
@@ -453,7 +453,7 @@ public:
     There's no need to propagate the sigma points through a process model,
     and we only have to add the process noise to the root covariance.
     */
-    void a_priori_step(real_t delta) {
+    void a_priori_step() {
         sigma_points = state.calculate_sigma_point_distribution(root_covariance *
             std::sqrt(StateVectorType::covariance_size() + Parameters::Lambda<StateVectorType>));
 

--- a/include/UKF/Core.h
+++ b/include/UKF/Core.h
@@ -134,13 +134,10 @@ public:
         z_prime = z_pred.template calculate_sigma_point_deltas<StateVectorType>(measurement_sigma_points);
 
         /*
-        Calculate innovation and innovation covariance. Innovation is simply
-        the difference between the measurement and the predicted measurement,
-        and innovation covariance is the sum of the predicted measurement
-        covariance and the measurement covariance.
+        Calculate innovation and innovation covariance.
         See equations 44 and 45 from the Kraft paper for details.
         */
-        innovation = z - z_pred;
+        innovation = z_pred.template calculate_innovation(z);
         innovation_covariance = z_pred.template calculate_sigma_point_covariance<StateVectorType>(z_prime);
         innovation_covariance += z.template calculate_measurement_covariance();
     }
@@ -304,12 +301,8 @@ public:
             z.template calculate_sigma_point_mean<StateVectorType>(measurement_sigma_points);
         z_prime = z_pred.template calculate_sigma_point_deltas<StateVectorType>(measurement_sigma_points);
 
-        /*
-        Calculate innovation and innovation root covariance. Innovation is
-        simply the difference between the measurement and the predicted
-        measurement.
-        */
-        innovation = z - z_pred;
+        /* Calculate innovation and innovation root covariance. */
+        innovation = z_pred.template calculate_innovation(z);
 
         /*
         Create an augmented matrix containing all but the centre innovation
@@ -490,12 +483,8 @@ public:
             z.template calculate_sigma_point_mean<StateVectorType>(measurement_sigma_points);
         z_prime = z_pred.template calculate_sigma_point_deltas<StateVectorType>(measurement_sigma_points);
 
-        /*
-        Calculate innovation and innovation root covariance. Innovation is
-        simply the difference between the measurement and the predicted
-        measurement.
-        */
-        innovation = z - z_pred;
+        /* Calculate innovation and innovation root covariance. */
+        innovation = z_pred.template calculate_innovation(z);
 
         /*
         Create an augmented matrix containing all but the centre innovation

--- a/include/UKF/Core.h
+++ b/include/UKF/Core.h
@@ -139,7 +139,7 @@ public:
         */
         innovation = z_pred.template calculate_innovation(z);
         innovation_covariance = z_pred.template calculate_sigma_point_covariance<StateVectorType>(z_prime);
-        innovation_covariance += z.template calculate_measurement_covariance();
+        innovation_covariance += z.template calculate_measurement_covariance(z_pred);
     }
 
     /*
@@ -324,7 +324,7 @@ public:
         augmented_z_prime.block(0, 0, z.size(), StateVectorType::num_sigma() - 1) =
             std::sqrt(Parameters::Sigma_WCI<StateVectorType>) * z_prime.rightCols(StateVectorType::num_sigma() - 1);
         augmented_z_prime.block(0, StateVectorType::num_sigma() - 1, z.size(), z.size()) =
-            z.template calculate_measurement_root_covariance();
+            z.template calculate_measurement_root_covariance(z_pred);
 
         /*
         Calculate the QR decomposition of the augmented innovation deltas.
@@ -506,7 +506,7 @@ public:
         augmented_z_prime.block(0, 0, z.size(), StateVectorType::num_sigma() - 1) =
             std::sqrt(Parameters::Sigma_WCI<StateVectorType>) * z_prime.rightCols(StateVectorType::num_sigma() - 1);
         augmented_z_prime.block(0, StateVectorType::num_sigma() - 1, z.size(), z.size()) =
-            z.template calculate_measurement_root_covariance();
+            z.template calculate_measurement_root_covariance(z_pred);
 
         /*
         Calculate the QR decomposition of the augmented innovation deltas.

--- a/include/UKF/Core.h
+++ b/include/UKF/Core.h
@@ -370,8 +370,8 @@ public:
         literature. Eigen's QR decomposition implements a left-division,
         rather than the right-division assumed in the literature.
         */
-        CrossCorrelation kalman_gain = innovation_root_covariance.transpose().householderQr().solve(
-            innovation_root_covariance.householderQr().solve(
+        CrossCorrelation kalman_gain = innovation_root_covariance.transpose().colPivHouseholderQr().solve(
+            innovation_root_covariance.colPivHouseholderQr().solve(
                 cross_correlation.transpose())).transpose();
 
         /*
@@ -552,8 +552,8 @@ public:
         literature. Eigen's QR decomposition implements a left-division,
         rather than the right-division assumed in the literature.
         */
-        CrossCorrelation kalman_gain = innovation_root_covariance.transpose().householderQr().solve(
-            innovation_root_covariance.householderQr().solve(
+        CrossCorrelation kalman_gain = innovation_root_covariance.transpose().colPivHouseholderQr().solve(
+            innovation_root_covariance.colPivHouseholderQr().solve(
                 cross_correlation.transpose())).transpose();
 
         /*

--- a/include/UKF/MeasurementVector.h
+++ b/include/UKF/MeasurementVector.h
@@ -318,13 +318,13 @@ private:
     }
 
     static Matrix<3, 3> field_covariance(const FieldVector& p, const FieldVector& z_pred, const FieldVector& z) {
-        Matrix<3, 3> temp = Detail::calculate_rotation_vector_jacobian<FixedMeasurementVector>(z, z_pred);
+        Matrix<3, 3> T = Detail::calculate_rotation_vector_jacobian<FixedMeasurementVector>(z, z_pred);
 
         /*
         To calculate the covariance, pre-multiply by the transformation matrix
         and then post-multiply by the transformation matrix transpose.
         */
-        return temp * p * temp.transpose();
+        return T * Eigen::DiagonalMatrix<real_t, 3>(p) * T.transpose();
     }
 
     template <typename T>
@@ -365,7 +365,8 @@ private:
 
         A proof of this is left as an exercise to the reader.
         */
-        return Detail::calculate_rotation_vector_jacobian<FixedMeasurementVector>(z, z_pred) * p;
+        return Detail::calculate_rotation_vector_jacobian<FixedMeasurementVector>(z, z_pred) *
+            Eigen::DiagonalMatrix<real_t, 3>(p);
     }
 
     template <typename T>
@@ -555,8 +556,7 @@ public:
         SigmaPointDeltas<S> z_prime(Base::template size(), S::num_sigma());
 
         /* Calculate the delta vectors. */
-        // calculate_field_deltas<S, Fields...>(Z, z_prime);
-        z_prime = Z.colwise() - *this;
+        calculate_field_deltas<S, Fields...>(Z, z_prime);
 
         return z_prime;
     }
@@ -696,9 +696,12 @@ private:
     }
 
     static Matrix<3, 3> field_covariance(const FieldVector& p, const FieldVector& z_pred, const FieldVector& z) {
-        Matrix<3, 3> temp = Detail::calculate_rotation_vector_jacobian<DynamicMeasurementVector>(z, z_pred);
-
-        return temp * p * temp.transpose();
+        Matrix<3, 3> T = Detail::calculate_rotation_vector_jacobian<DynamicMeasurementVector>(z, z_pred);
+        /*
+        To calculate the covariance, pre-multiply by the transformation matrix
+        and then post-multiply by the transformation matrix transpose.
+        */
+        return T * Eigen::DiagonalMatrix<real_t, 3>(p) * T.transpose();
     }
 
     template <typename T>
@@ -738,7 +741,8 @@ private:
     }
 
     static Matrix<3, 3> field_root_covariance(const FieldVector& p, const FieldVector& z_pred, const FieldVector& z) {
-        return Detail::calculate_rotation_vector_jacobian<DynamicMeasurementVector>(z, z_pred) * p;
+        return Detail::calculate_rotation_vector_jacobian<DynamicMeasurementVector>(z, z_pred) *
+            Eigen::DiagonalMatrix<real_t, 3>(p);
     }
 
     template <typename T>

--- a/include/UKF/StateVector.h
+++ b/include/UKF/StateVector.h
@@ -560,8 +560,8 @@ private:
         */
         for(std::size_t i = 0; i < num_sigma(); i++) {
             Quaternion delta_q = Quaternion(X.col(i)) * mean.conjugate();
-            temp.col(i) = Parameters::MRP_F<StateVector>
-                * (delta_q.vec() / (Parameters::MRP_A<StateVector> + delta_q.w()));
+            temp.col(i) = Parameters::MRP_F<StateVector> * delta_q.vec() /
+                std::max(Parameters::MRP_A<StateVector> + delta_q.w(), std::numeric_limits<real_t>::epsilon());
         }
 
         return temp;

--- a/include/UKF/StateVector.h
+++ b/include/UKF/StateVector.h
@@ -561,7 +561,8 @@ private:
         for(std::size_t i = 0; i < num_sigma(); i++) {
             Quaternion delta_q = Quaternion(X.col(i)) * mean.conjugate();
             temp.col(i) = Parameters::MRP_F<StateVector> * delta_q.vec() /
-                std::max(Parameters::MRP_A<StateVector> + delta_q.w(), std::numeric_limits<real_t>::epsilon());
+                (std::abs(Parameters::MRP_A<StateVector> + delta_q.w()) > std::numeric_limits<real_t>::epsilon() ?
+                    Parameters::MRP_A<StateVector> + delta_q.w() : std::numeric_limits<real_t>::epsilon());
         }
 
         return temp;

--- a/include/UKF/Types.h
+++ b/include/UKF/Types.h
@@ -45,6 +45,14 @@ using VectorDynamic = Eigen::Matrix<real_t, Eigen::Dynamic, 1, 0, Length, 1>;
 
 using Quaternion = Eigen::Quaternion<real_t>;
 
+class FieldVector : public Vector<3> {
+public:
+	/* Inherit Eigen::Matrix constructors and assignment operators. */
+    using Base = Vector<3>;
+    using Base::Base;
+    using Base::operator=;
+};
+
 }
 
 #endif

--- a/test/TestCore.cpp
+++ b/test/TestCore.cpp
@@ -72,7 +72,7 @@ using MyMeasurementVector = UKF::DynamicMeasurementVector<
     UKF::Field<GPS_Position, UKF::Vector<3>>,
     UKF::Field<GPS_Velocity, UKF::Vector<3>>,
     UKF::Field<Accelerometer, UKF::Vector<3>>,
-    UKF::Field<Magnetometer, UKF::Vector<3>>,
+    UKF::Field<Magnetometer, UKF::FieldVector>,
     UKF::Field<Gyroscope, UKF::Vector<3>>
 >;
 
@@ -105,9 +105,9 @@ UKF::Vector<3> MyMeasurementVector::expected_measurement
 }
 
 template <> template <>
-UKF::Vector<3> MyMeasurementVector::expected_measurement
+UKF::FieldVector MyMeasurementVector::expected_measurement
 <MyStateVector, Magnetometer>(const MyStateVector& state) {
-    return state.get_field<Attitude>() * UKF::Vector<3>(1, 0, 0);
+    return state.get_field<Attitude>() * UKF::FieldVector(1, 0, 0);
 }
 
 template <> template <>
@@ -144,10 +144,10 @@ UKF::Vector<3> MyMeasurementVector::expected_measurement
 }
 
 template <> template <>
-UKF::Vector<3> MyMeasurementVector::expected_measurement
+UKF::FieldVector MyMeasurementVector::expected_measurement
 <MyStateVector, Magnetometer, UKF::Vector<3>>(const MyStateVector& state,
         const UKF::Vector<3>& acceleration, const UKF::Vector<3>& angular_acceleration) {
-    return state.get_field<Attitude>() * UKF::Vector<3>(1, 0, 0);
+    return state.get_field<Attitude>() * UKF::FieldVector(1, 0, 0);
 }
 
 template <> template <>
@@ -239,7 +239,7 @@ TEST(CoreTest, InnovationStep) {
     m.set_field<GPS_Position>(UKF::Vector<3>(100, 10, -50));
     m.set_field<GPS_Velocity>(UKF::Vector<3>(20, 0, 0));
     m.set_field<Accelerometer>(UKF::Vector<3>(0, 0, -9.8));
-    m.set_field<Magnetometer>(UKF::Vector<3>(0, -1, 0));
+    m.set_field<Magnetometer>(UKF::FieldVector(0, -1, 0));
     m.set_field<Gyroscope>(UKF::Vector<3>(0.5, 0, 0));
 
     test_filter.a_priori_step(0.01);
@@ -265,7 +265,7 @@ TEST(CoreTest, InnovationStepPartialMeasurement) {
     MyMeasurementVector m;
 
     m.set_field<Accelerometer>(UKF::Vector<3>(0, 0, -9.8));
-    m.set_field<Magnetometer>(UKF::Vector<3>(0, -1, 0));
+    m.set_field<Magnetometer>(UKF::FieldVector(0, -1, 0));
     m.set_field<Gyroscope>(UKF::Vector<3>(0.5, 0, 0));
 
     test_filter.a_priori_step(0.01);
@@ -293,7 +293,7 @@ TEST(CoreTest, InnovationStepWithInputs) {
     m.set_field<GPS_Position>(UKF::Vector<3>(100, 10, -50));
     m.set_field<GPS_Velocity>(UKF::Vector<3>(20, 0, 0));
     m.set_field<Accelerometer>(UKF::Vector<3>(0, 0, -15));
-    m.set_field<Magnetometer>(UKF::Vector<3>(0, -1, 0));
+    m.set_field<Magnetometer>(UKF::FieldVector(0, -1, 0));
     m.set_field<Gyroscope>(UKF::Vector<3>(0.5, 0, 0));
 
     test_filter.a_priori_step(0.01, UKF::Vector<3>(0, 0, -5), UKF::Vector<3>(1, 0, 0));
@@ -319,7 +319,7 @@ TEST(CoreTest, InnovationStepPartialMeasurementWithInputs) {
     MyMeasurementVector m;
 
     m.set_field<Accelerometer>(UKF::Vector<3>(0, 0, -15));
-    m.set_field<Magnetometer>(UKF::Vector<3>(0, -1, 0));
+    m.set_field<Magnetometer>(UKF::FieldVector(0, -1, 0));
     m.set_field<Gyroscope>(UKF::Vector<3>(0.5, 0, 0));
 
     test_filter.a_priori_step(0.01, UKF::Vector<3>(0, 0, -5), UKF::Vector<3>(1, 0, 0));
@@ -347,7 +347,7 @@ TEST(CoreTest, APosterioriStep) {
     m.set_field<GPS_Position>(UKF::Vector<3>(100, 10, -50));
     m.set_field<GPS_Velocity>(UKF::Vector<3>(20, 0, 0));
     m.set_field<Accelerometer>(UKF::Vector<3>(0, 0, -9.8));
-    m.set_field<Magnetometer>(UKF::Vector<3>(0, -1, 0));
+    m.set_field<Magnetometer>(UKF::FieldVector(0, -1, 0));
     m.set_field<Gyroscope>(UKF::Vector<3>(0.5, 0, 0));
 
     test_filter.a_priori_step(0.01);
@@ -372,7 +372,7 @@ TEST(CoreTest, FullStep) {
     m.set_field<GPS_Position>(UKF::Vector<3>(100, 10, -50));
     m.set_field<GPS_Velocity>(UKF::Vector<3>(20, 0, 0));
     m.set_field<Accelerometer>(UKF::Vector<3>(0, 0, -14.8));
-    m.set_field<Magnetometer>(UKF::Vector<3>(0, -1, 0));
+    m.set_field<Magnetometer>(UKF::FieldVector(0, -1, 0));
     m.set_field<Gyroscope>(UKF::Vector<3>(0.5, 0, 0));
 
     test_filter.step(0.01, m, UKF::Vector<3>(0, 0, -5), UKF::Vector<3>(1, 0, 0));

--- a/test/TestCore.cpp
+++ b/test/TestCore.cpp
@@ -205,7 +205,7 @@ TEST(CoreTest, APrioriStep) {
 
     test_filter.a_priori_step(0.01);
 
-    EXPECT_TRUE(test_filter.covariance.llt().info() == Eigen::Success);
+    EXPECT_GT(test_filter.covariance.determinant(), std::numeric_limits<real_t>::epsilon());
     EXPECT_LT((UKF::Vector<3>(100, 10, -50) - test_filter.state.get_field<Position>()).norm(),
         std::sqrt(test_filter.covariance.diagonal().segment<3>(0).norm())*2);
     EXPECT_LT((UKF::Vector<3>(20, 0, 0) - test_filter.state.get_field<Velocity>()).norm(),
@@ -221,7 +221,7 @@ TEST(CoreTest, APrioriStepWithInputs) {
 
     test_filter.a_priori_step(0.01, UKF::Vector<3>(0, 0, -5), UKF::Vector<3>(1, 0, 0));
 
-    EXPECT_TRUE(test_filter.covariance.llt().info() == Eigen::Success);
+    EXPECT_GT(test_filter.covariance.determinant(), std::numeric_limits<real_t>::epsilon());
     EXPECT_LT((UKF::Vector<3>(100, 10, -50) - test_filter.state.get_field<Position>()).norm(),
         std::sqrt(test_filter.covariance.diagonal().segment<3>(0).norm())*2);
     EXPECT_LT((UKF::Vector<3>(20, 0, 0) - test_filter.state.get_field<Velocity>()).norm(),
@@ -245,11 +245,15 @@ TEST(CoreTest, InnovationStep) {
     test_filter.a_priori_step(0.01);
     test_filter.innovation_step(m);
 
-    EXPECT_TRUE(test_filter.innovation_covariance.llt().info() == Eigen::Success);
+    /*
+    With the field vector, we expect the determinant to be approximately zero,
+    so allow for it to be slightly negative due to numerical precision.
+    */
+    EXPECT_GE(test_filter.innovation_covariance.determinant(), -std::numeric_limits<real_t>::epsilon());
 
     test_filter.a_posteriori_step();
 
-    EXPECT_TRUE(test_filter.covariance.llt().info() == Eigen::Success);
+    EXPECT_GT(test_filter.covariance.determinant(), std::numeric_limits<real_t>::epsilon());
     EXPECT_LT((UKF::Vector<3>(100, 10, -50) - test_filter.state.get_field<Position>()).norm(),
         std::sqrt(test_filter.covariance.diagonal().segment<3>(0).norm())*2);
     EXPECT_LT((UKF::Vector<3>(20, 0, 0) - test_filter.state.get_field<Velocity>()).norm(),
@@ -271,11 +275,11 @@ TEST(CoreTest, InnovationStepPartialMeasurement) {
     test_filter.a_priori_step(0.01);
     test_filter.innovation_step(m);
 
-    EXPECT_TRUE(test_filter.innovation_covariance.llt().info() == Eigen::Success);
+    EXPECT_GE(test_filter.innovation_covariance.determinant(), -std::numeric_limits<real_t>::epsilon());
 
     test_filter.a_posteriori_step();
 
-    EXPECT_TRUE(test_filter.covariance.llt().info() == Eigen::Success);
+    EXPECT_GT(test_filter.covariance.determinant(), std::numeric_limits<real_t>::epsilon());
     EXPECT_LT((UKF::Vector<3>(100, 10, -50) - test_filter.state.get_field<Position>()).norm(),
         std::sqrt(test_filter.covariance.diagonal().segment<3>(0).norm())*2);
     EXPECT_LT((UKF::Vector<3>(20, 0, 0) - test_filter.state.get_field<Velocity>()).norm(),
@@ -299,11 +303,11 @@ TEST(CoreTest, InnovationStepWithInputs) {
     test_filter.a_priori_step(0.01, UKF::Vector<3>(0, 0, -5), UKF::Vector<3>(1, 0, 0));
     test_filter.innovation_step(m, UKF::Vector<3>(0, 0, -5), UKF::Vector<3>(1, 0, 0));
 
-    EXPECT_TRUE(test_filter.innovation_covariance.llt().info() == Eigen::Success);
+    EXPECT_GE(test_filter.innovation_covariance.determinant(), -std::numeric_limits<real_t>::epsilon());
 
     test_filter.a_posteriori_step();
 
-    EXPECT_TRUE(test_filter.covariance.llt().info() == Eigen::Success);
+    EXPECT_GT(test_filter.covariance.determinant(), std::numeric_limits<real_t>::epsilon());
     EXPECT_LT((UKF::Vector<3>(100, 10, -50) - test_filter.state.get_field<Position>()).norm(),
         std::sqrt(test_filter.covariance.diagonal().segment<3>(0).norm())*2);
     EXPECT_LT((UKF::Vector<3>(20, 0, 0) - test_filter.state.get_field<Velocity>()).norm(),
@@ -325,11 +329,11 @@ TEST(CoreTest, InnovationStepPartialMeasurementWithInputs) {
     test_filter.a_priori_step(0.01, UKF::Vector<3>(0, 0, -5), UKF::Vector<3>(1, 0, 0));
     test_filter.innovation_step(m, UKF::Vector<3>(0, 0, -5), UKF::Vector<3>(1, 0, 0));
 
-    EXPECT_TRUE(test_filter.innovation_covariance.llt().info() == Eigen::Success);
+    EXPECT_GE(test_filter.innovation_covariance.determinant(), -std::numeric_limits<real_t>::epsilon());
 
     test_filter.a_posteriori_step();
 
-    EXPECT_TRUE(test_filter.covariance.llt().info() == Eigen::Success);
+    EXPECT_GT(test_filter.covariance.determinant(), std::numeric_limits<real_t>::epsilon());
     EXPECT_LT((UKF::Vector<3>(100, 10, -50) - test_filter.state.get_field<Position>()).norm(),
         std::sqrt(test_filter.covariance.diagonal().segment<3>(0).norm())*2);
     EXPECT_LT((UKF::Vector<3>(20, 0, 0) - test_filter.state.get_field<Velocity>()).norm(),
@@ -354,7 +358,7 @@ TEST(CoreTest, APosterioriStep) {
     test_filter.innovation_step(m);
     test_filter.a_posteriori_step();
 
-    EXPECT_TRUE(test_filter.covariance.llt().info() == Eigen::Success);
+    EXPECT_GT(test_filter.covariance.determinant(), std::numeric_limits<real_t>::epsilon());
     EXPECT_LT((UKF::Vector<3>(100, 10, -50) - test_filter.state.get_field<Position>()).norm(),
         std::sqrt(test_filter.covariance.diagonal().segment<3>(0).norm())*2);
     EXPECT_LT((UKF::Vector<3>(20, 0, 0) - test_filter.state.get_field<Velocity>()).norm(),
@@ -377,7 +381,7 @@ TEST(CoreTest, FullStep) {
 
     test_filter.step(0.01, m, UKF::Vector<3>(0, 0, -5), UKF::Vector<3>(1, 0, 0));
 
-    EXPECT_TRUE(test_filter.covariance.llt().info() == Eigen::Success);
+    EXPECT_GT(test_filter.covariance.determinant(), std::numeric_limits<real_t>::epsilon());
     EXPECT_LT((UKF::Vector<3>(100, 10, -50) - test_filter.state.get_field<Position>()).norm(),
         std::sqrt(test_filter.covariance.diagonal().segment<3>(0).norm())*2);
     EXPECT_LT((UKF::Vector<3>(20, 0, 0) - test_filter.state.get_field<Velocity>()).norm(),

--- a/test/TestDynamicMeasurementVector.cpp
+++ b/test/TestDynamicMeasurementVector.cpp
@@ -10,12 +10,14 @@ enum MyFields {
     StaticPressure,
     DynamicPressure,
     Accelerometer,
-    Gyroscope
+    Gyroscope,
+    Magnetometer
 };
 
 using MyMeasurementVector = UKF::DynamicMeasurementVector<
     UKF::Field<StaticPressure, real_t>,
     UKF::Field<DynamicPressure, real_t>,
+    UKF::Field<Magnetometer, UKF::FieldVector>,
     UKF::Field<Accelerometer, UKF::Vector<3>>,
     UKF::Field<Gyroscope, UKF::Vector<3>>
 >;
@@ -23,8 +25,8 @@ using MyMeasurementVector = UKF::DynamicMeasurementVector<
 TEST(DynamicMeasurementVectorTest, Instantiation) {
     MyMeasurementVector test_measurement;
 
-    EXPECT_EQ(8, MyMeasurementVector::MaxRowsAtCompileTime);
-    EXPECT_EQ(8, test_measurement.max_size());
+    EXPECT_EQ(11, MyMeasurementVector::MaxRowsAtCompileTime);
+    EXPECT_EQ(11, test_measurement.max_size());
 }
 
 TEST(DynamicMeasurementVectorTest, Assignment) {
@@ -50,8 +52,13 @@ TEST(DynamicMeasurementVectorTest, Assignment) {
     EXPECT_EQ(8, test_measurement.size());
     EXPECT_EQ(8, test_measurement.get_field<StaticPressure>());
 
-    UKF::Vector<8> expected;
-    expected << 1, 2, 3, 4, 5, 6, 7, 8;
+    test_measurement.set_field<Magnetometer>(UKF::FieldVector(9, 10, 11));
+
+    EXPECT_EQ(11, test_measurement.size());
+    EXPECT_VECTOR_EQ(UKF::FieldVector(9, 10, 11), test_measurement.get_field<Magnetometer>());
+
+    UKF::Vector<11> expected;
+    expected << 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11;
     EXPECT_VECTOR_EQ(expected, test_measurement);
 }
 
@@ -78,38 +85,46 @@ TEST(DynamicMeasurementVectorTest, MultipleReassignment) {
     test_measurement.set_field<DynamicPressure>(4);
     test_measurement.set_field<Accelerometer>(UKF::Vector<3>(5, 6, 7));
     test_measurement.set_field<StaticPressure>(8);
+    test_measurement.set_field<Magnetometer>(UKF::FieldVector(9, 10, 11));
 
-    EXPECT_EQ(8, test_measurement.size());
-    UKF::Vector<8> expected;
-    expected << 1, 2, 3, 4, 5, 6, 7, 8;
+    EXPECT_EQ(11, test_measurement.size());
+    UKF::Vector<11> expected;
+    expected << 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11;
     EXPECT_VECTOR_EQ(expected, test_measurement);
 
     test_measurement.set_field<Gyroscope>(UKF::Vector<3>(4, 5, 6));
 
-    EXPECT_EQ(8, test_measurement.size());
+    EXPECT_EQ(11, test_measurement.size());
     EXPECT_VECTOR_EQ(UKF::Vector<3>(4, 5, 6), test_measurement.get_field<Gyroscope>());
-    expected << 4, 5, 6, 4, 5, 6, 7, 8;
+    expected << 4, 5, 6, 4, 5, 6, 7, 8, 9, 10, 11;
     EXPECT_VECTOR_EQ(expected, test_measurement);
 
     test_measurement.set_field<Accelerometer>(UKF::Vector<3>(7, 8, 9));
 
-    EXPECT_EQ(8, test_measurement.size());
+    EXPECT_EQ(11, test_measurement.size());
     EXPECT_VECTOR_EQ(UKF::Vector<3>(7, 8, 9), test_measurement.get_field<Accelerometer>());
-    expected << 4, 5, 6, 4, 7, 8, 9, 8;
+    expected << 4, 5, 6, 4, 7, 8, 9, 8, 9, 10, 11;
     EXPECT_VECTOR_EQ(expected, test_measurement);
 
     test_measurement.set_field<DynamicPressure>(1);
 
-    EXPECT_EQ(8, test_measurement.size());
+    EXPECT_EQ(11, test_measurement.size());
     EXPECT_EQ(1, test_measurement.get_field<DynamicPressure>());
-    expected << 4, 5, 6, 1, 7, 8, 9, 8;
+    expected << 4, 5, 6, 1, 7, 8, 9, 8, 9, 10, 11;
     EXPECT_VECTOR_EQ(expected, test_measurement);
 
     test_measurement.set_field<StaticPressure>(3);
 
-    EXPECT_EQ(8, test_measurement.size());
+    EXPECT_EQ(11, test_measurement.size());
     EXPECT_EQ(3, test_measurement.get_field<StaticPressure>());
-    expected << 4, 5, 6, 1, 7, 8, 9, 3;
+    expected << 4, 5, 6, 1, 7, 8, 9, 3, 9, 10, 11;
+    EXPECT_VECTOR_EQ(expected, test_measurement);
+
+    test_measurement.set_field<Magnetometer>(UKF::FieldVector(4, 5, 6));
+
+    EXPECT_EQ(11, test_measurement.size());
+    EXPECT_VECTOR_EQ(UKF::FieldVector(4, 5, 6), test_measurement.get_field<Magnetometer>());
+    expected << 4, 5, 6, 1, 7, 8, 9, 3, 4, 5, 6;
     EXPECT_VECTOR_EQ(expected, test_measurement);
 }
 
@@ -120,6 +135,7 @@ TEST(DynamicMeasurementVectorTest, CopyConstructor) {
     test_measurement_1.set_field<DynamicPressure>(4);
     test_measurement_1.set_field<Accelerometer>(UKF::Vector<3>(5, 6, 7));
     test_measurement_1.set_field<StaticPressure>(8);
+    test_measurement_1.set_field<Magnetometer>(UKF::FieldVector(9, 10, 11));
 
     test_measurement_2 = test_measurement_1;
 
@@ -129,10 +145,7 @@ TEST(DynamicMeasurementVectorTest, CopyConstructor) {
     EXPECT_EQ(4, test_measurement_2.get_field<DynamicPressure>());
     EXPECT_VECTOR_EQ(UKF::Vector<3>(5, 6, 7), test_measurement_2.get_field<Accelerometer>());
     EXPECT_EQ(8, test_measurement_2.get_field<StaticPressure>());
-}
-
-TEST(DynamicMeasurementVectorTest, Arithmetic) {
-    
+    EXPECT_VECTOR_EQ(UKF::FieldVector(9, 10, 11), test_measurement_2.get_field<Magnetometer>());
 }
 
 enum MyStateVectorFields {
@@ -177,6 +190,12 @@ real_t MyMeasurementVector::expected_measurement
     return 0.5 * 1.225 * state.get_field<Velocity>().squaredNorm();
 }
 
+template <> template <>
+UKF::FieldVector MyMeasurementVector::expected_measurement
+<MyStateVector, Magnetometer>(const MyStateVector& state) {
+    return state.get_field<Attitude>() * UKF::FieldVector(0.45, 0, 0);
+}
+
 /*
 These versions of the predicted measurement functions have non-state inputs.
 This could be used to add predicted kinematic acceleration by feeding control
@@ -206,12 +225,19 @@ real_t MyMeasurementVector::expected_measurement
     return 0.5 * 1.225 * state.get_field<Velocity>().squaredNorm();
 }
 
+template <> template <>
+UKF::FieldVector MyMeasurementVector::expected_measurement
+<MyStateVector, Magnetometer, UKF::Vector<3>>(const MyStateVector& state, const UKF::Vector<3>& input) {
+    return state.get_field<Attitude>() * UKF::FieldVector(0.45, 0, 0) + input;
+}
+
 TEST(DynamicMeasurementVectorTest, SigmaPointGeneration) {
     MyStateVector test_state;
     MyMeasurementVector test_measurement;
 
     test_measurement.set_field<Accelerometer>(UKF::Vector<3>(0, 0, 0));
     test_measurement.set_field<Gyroscope>(UKF::Vector<3>(0, 0, 0));
+    test_measurement.set_field<Magnetometer>(UKF::FieldVector(0, 0, 0));
     test_measurement.set_field<StaticPressure>(0);
     test_measurement.set_field<DynamicPressure>(0);
 
@@ -235,6 +261,9 @@ TEST(DynamicMeasurementVectorTest, SigmaPointGeneration) {
                             1,      1,      1,      1,  4.606,      1,      1,      1,      1,      1,      1,      1,      1,      1, -2.606,      1,      1,      1,      1,      1,      1,
                             0,      0,      0,      0,      0,  3.606,      0,      0,      0,      0,      0,      0,      0,      0,      0, -3.606,      0,      0,      0,      0,      0,
                             0,      0,      0,      0,      0,      0,  3.606,      0,      0,      0,      0,      0,      0,      0,      0,      0, -3.606,      0,      0,      0,      0,
+                         0.45,   0.45,   0.45,   0.45,   0.45,   0.45,   0.45,   0.45, -0.238, -0.238,   0.45,   0.45,   0.45,   0.45,   0.45,   0.45,   0.45,   0.45, -0.238, -0.238,   0.45,
+                            0,      0,      0,      0,      0,      0,      0,      0,      0,  0.382,      0,      0,      0,      0,      0,      0,      0,      0,      0, -0.382,      0,
+                            0,      0,      0,      0,      0,      0,      0,      0, -0.382,      0,      0,      0,      0,      0,      0,      0,      0,      0,  0.382,      0,      0,
                          89.3,   89.3,   89.3,   89.3,   89.3,   89.3,   89.3,   89.3,   89.3,   89.3, 89.257,   89.3,   89.3,   89.3,   89.3,   89.3,   89.3,   89.3,   89.3,   89.3, 89.343,
                         8.575, 20.954, 25.371, 29.788,  8.575,  8.575,  8.575,  8.575,  8.575,  8.575,  8.575, 12.121,  7.704,  3.287,  8.575,  8.575,  8.575,  8.575,  8.575,  8.575,  8.575;
     MyMeasurementVector::SigmaPointDistribution<MyStateVector> measurement_sigma_points;
@@ -269,6 +298,7 @@ TEST(DynamicMeasurementVectorTest, SigmaPointGenerationWithInput) {
 
     test_measurement.set_field<Accelerometer>(UKF::Vector<3>(0, 0, 0));
     test_measurement.set_field<Gyroscope>(UKF::Vector<3>(0, 0, 0));
+    test_measurement.set_field<Magnetometer>(UKF::FieldVector(0, 0, 0));
     test_measurement.set_field<StaticPressure>(0);
     test_measurement.set_field<DynamicPressure>(0);
 
@@ -292,6 +322,9 @@ TEST(DynamicMeasurementVectorTest, SigmaPointGenerationWithInput) {
                             1,      1,      1,      1,  4.606,      1,      1,      1,      1,      1,      1,      1,      1,      1, -2.606,      1,      1,      1,      1,      1,      1,
                             0,      0,      0,      0,      0,  3.606,      0,      0,      0,      0,      0,      0,      0,      0,      0, -3.606,      0,      0,      0,      0,      0,
                             0,      0,      0,      0,      0,      0,  3.606,      0,      0,      0,      0,      0,      0,      0,      0,      0, -3.606,      0,      0,      0,      0,
+                         1.45,   1.45,   1.45,   1.45,   1.45,   1.45,   1.45,   1.45,  0.762,  0.762,   1.45,   1.45,   1.45,   1.45,   1.45,   1.45,   1.45,   1.45,  0.762,  0.762,   1.45,
+                            2,      2,      2,      2,      2,      2,      2,      2,      2,  2.382,      2,      2,      2,      2,      2,      2,      2,      2,      2,  1.618,      2,
+                            3,      3,      3,      3,      3,      3,      3,      3,  2.618,      3,      3,      3,      3,      3,      3,      3,      3,      3,  3.382,      3,      3,
                          89.3,   89.3,   89.3,   89.3,   89.3,   89.3,   89.3,   89.3,   89.3,   89.3, 89.257,   89.3,   89.3,   89.3,   89.3,   89.3,   89.3,   89.3,   89.3,   89.3, 89.343,
                         8.575, 20.954, 25.371, 29.788,  8.575,  8.575,  8.575,  8.575,  8.575,  8.575,  8.575, 12.121,  7.704,  3.287,  8.575,  8.575,  8.575,  8.575,  8.575,  8.575,  8.575;
     MyMeasurementVector::SigmaPointDistribution<MyStateVector> measurement_sigma_points;
@@ -377,6 +410,7 @@ TEST(DynamicMeasurementVectorTest, SigmaPointMean) {
 
     test_measurement.set_field<Accelerometer>(UKF::Vector<3>(0, 0, 0));
     test_measurement.set_field<Gyroscope>(UKF::Vector<3>(0, 0, 0));
+    test_measurement.set_field<Magnetometer>(UKF::FieldVector(0, 0, 0));
     test_measurement.set_field<StaticPressure>(0);
     test_measurement.set_field<DynamicPressure>(0);
 
@@ -386,6 +420,9 @@ TEST(DynamicMeasurementVectorTest, SigmaPointMean) {
                                  1,      1,      1,      1,  4.606,      1,      1,      1,      1,      1,      1,      1,      1,      1, -2.606,      1,      1,      1,      1,      1,      1,
                                  0,      0,      0,      0,      0,  3.606,      0,      0,      0,      0,      0,      0,      0,      0,      0, -3.606,      0,      0,      0,      0,      0,
                                  0,      0,      0,      0,      0,      0,  3.606,      0,      0,      0,      0,      0,      0,      0,      0,      0, -3.606,      0,      0,      0,      0,
+                              0.45,   0.45,   0.45,   0.45,   0.45,   0.45,   0.45,   0.45, -0.238, -0.238,   0.45,   0.45,   0.45,   0.45,   0.45,   0.45,   0.45,   0.45, -0.238, -0.238,   0.45,
+                                 0,      0,      0,      0,      0,      0,      0,      0,      0,  0.382,      0,      0,      0,      0,      0,      0,      0,      0,      0, -0.382,      0,
+                                 0,      0,      0,      0,      0,      0,      0,      0, -0.382,      0,      0,      0,      0,      0,      0,      0,      0,      0,  0.382,      0,      0,
                               89.3,   89.3,   89.3,   89.3,   89.3,   89.3,   89.3,   89.3,   89.3,   89.3, 89.257,   89.3,   89.3,   89.3,   89.3,   89.3,   89.3,   89.3,   89.3,   89.3, 89.343,
                              8.575, 20.954, 25.371, 29.788,  8.575,  8.575,  8.575,  8.575,  8.575,  8.575,  8.575, 12.121,  7.704,  3.287,  8.575,  8.575,  8.575,  8.575,  8.575,  8.575,  8.575;
 
@@ -393,6 +430,7 @@ TEST(DynamicMeasurementVectorTest, SigmaPointMean) {
 
     expected_mean.set_field<Accelerometer>(UKF::Vector<3>(0.0, 0.0, -7.494));
     expected_mean.set_field<Gyroscope>(UKF::Vector<3>(1.0, 0.0, 0.0));
+    expected_mean.set_field<Magnetometer>(UKF::FieldVector(0.344, 0, 0));
     expected_mean.set_field<StaticPressure>(89.3);
     expected_mean.set_field<DynamicPressure>(10.4125);
 
@@ -423,6 +461,7 @@ TEST(DynamicMeasurementVectorTest, SigmaPointDeltas) {
 
     test_measurement.set_field<Accelerometer>(UKF::Vector<3>(0, 0, 0));
     test_measurement.set_field<Gyroscope>(UKF::Vector<3>(0, 0, 0));
+    test_measurement.set_field<Magnetometer>(UKF::FieldVector(1, 0, 0));
     test_measurement.set_field<StaticPressure>(0);
     test_measurement.set_field<DynamicPressure>(0);
 
@@ -444,14 +483,17 @@ TEST(DynamicMeasurementVectorTest, SigmaPointDeltas) {
     MyMeasurementVector::SigmaPointDeltas<MyStateVector> sigma_point_deltas(mean_measurement.size(), MyStateVector::num_sigma());
     MyMeasurementVector::SigmaPointDeltas<MyStateVector> target_sigma_point_deltas(mean_measurement.size(), MyStateVector::num_sigma());
 
-    target_sigma_point_deltas <<       0,       0,       0,       0,       0,       0,       0,       0,  -8.314,       0,       0,      0,       0,       0,       0,       0,       0,       0,   8.314,       0,       0,
-                                       0,       0,       0,       0,       0,       0,       0,   8.314,       0,       0,       0,      0,       0,       0,       0,       0,       0,  -8.314,       0,       0,       0,
-                                  -2.306,  -2.306,  -2.306,  -2.306,  -2.306,  -2.306,  -2.306,  12.682,  12.682,  -2.306,  -2.306, -2.306,  -2.306,  -2.306,  -2.306,  -2.306,  -2.306,  12.682,  12.682,  -2.306,  -2.306,
-                                       0,       0,       0,       0,   3.606,       0,       0,       0,       0,       0,       0,      0,       0,       0,  -3.606,       0,       0,       0,       0,       0,       0,
-                                       0,       0,       0,       0,       0,   3.606,       0,       0,       0,       0,       0,      0,       0,       0,       0,  -3.606,       0,       0,       0,       0,       0,
-                                       0,       0,       0,       0,       0,       0,   3.606,       0,       0,       0,       0,      0,       0,       0,       0,       0,  -3.606,       0,       0,       0,       0,
-                                       0,       0,       0,       0,       0,       0,       0,       0,       0,       0,  -0.043,      0,       0,       0,       0,       0,       0,       0,       0,       0,   0.043,
-                                 -1.8375,  10.542,  14.959,  19.376, -1.8375, -1.8375, -1.8375, -1.8375, -1.8375, -1.8375, -1.8375, 1.7082, -2.7086,  -7.126, -1.8375, -1.8375, -1.8375, -1.8375, -1.8375, -1.8375, -1.8375;
+    target_sigma_point_deltas <<       0,       0,       0,       0,       0,       0,       0,       0,  -8.314,       0,       0,       0,       0,       0,       0,       0,       0,       0,   8.314,       0,       0,
+                                       0,       0,       0,       0,       0,       0,       0,   8.314,       0,       0,       0,       0,       0,       0,       0,       0,       0,  -8.314,       0,       0,       0,
+                                  -2.306,  -2.306,  -2.306,  -2.306,  -2.306,  -2.306,  -2.306,  12.682,  12.682,  -2.306,  -2.306,  -2.306,  -2.306,  -2.306,  -2.306,  -2.306,  -2.306,  12.682,  12.682,  -2.306,  -2.306,
+                                       0,       0,       0,       0,   3.606,       0,       0,       0,       0,       0,       0,       0,       0,       0,  -3.606,       0,       0,       0,       0,       0,       0,
+                                       0,       0,       0,       0,       0,   3.606,       0,       0,       0,       0,       0,       0,       0,       0,       0,  -3.606,       0,       0,       0,       0,       0,
+                                       0,       0,       0,       0,       0,       0,   3.606,       0,       0,       0,       0,       0,       0,       0,       0,       0,  -3.606,       0,       0,       0,       0,
+                                       0,       0,       0,       0,       0,       0,       0,       0,       0,       0,       0,       0,       0,       0,       0,       0,       0,       0,       0,       0,       0,
+                                       0,       0,       0,       0,       0,       0,       0,       0,   3.606,       0,       0,       0,       0,       0,       0,       0,       0,       0,  -3.606,       0,       0,
+                                       0,       0,       0,       0,       0,       0,       0,       0,       0,   3.606,       0,       0,       0,       0,       0,       0,       0,       0,       0,  -3.606,       0,
+                                       0,       0,       0,       0,       0,       0,       0,       0,       0,       0,  -0.043,       0,       0,       0,       0,       0,       0,       0,       0,       0,   0.043,
+                                 -1.8375,  10.542,  14.959,  19.376, -1.8375, -1.8375, -1.8375, -1.8375, -1.8375, -1.8375, -1.8375,  1.7082, -2.7086,  -7.126, -1.8375, -1.8375, -1.8375, -1.8375, -1.8375, -1.8375, -1.8375;
     sigma_point_deltas = mean_measurement.calculate_sigma_point_deltas<MyStateVector>(measurement_sigma_points);
 
     EXPECT_VECTOR_EQ(target_sigma_point_deltas.col(0),  sigma_point_deltas.col(0));
@@ -542,6 +584,7 @@ TEST(DynamicMeasurementVectorTest, Innovation) {
     test_measurement.set_field<DynamicPressure>(0.5 * 122.5);
     test_measurement.set_field<Accelerometer>(UKF::Vector<3>(0, 0, 9.8));
     test_measurement.set_field<StaticPressure>(101.3);
+    test_measurement.set_field<Magnetometer>(UKF::FieldVector(0, 0.45, 0));
 
     MyStateVector::CovarianceMatrix covariance = MyStateVector::CovarianceMatrix::Zero();
     covariance.diagonal() << 1e-9, 1e-9, 1e-9, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0;
@@ -558,6 +601,7 @@ TEST(DynamicMeasurementVectorTest, Innovation) {
     target_innovation.set_field<DynamicPressure>(0);
     target_innovation.set_field<Accelerometer>(UKF::Vector<3>(0, 0, 17.294));
     target_innovation.set_field<StaticPressure>(12.0);
+    target_innovation.set_field<Magnetometer>(UKF::FieldVector(0, 0, 2));
 
     EXPECT_VECTOR_EQ(target_innovation, mean_measurement.calculate_innovation(test_measurement));
 }
@@ -595,6 +639,7 @@ TEST(DynamicMeasurementVectorTest, SigmaPointCovariance) {
 
     test_measurement.set_field<Accelerometer>(UKF::Vector<3>(0, 0, 0));
     test_measurement.set_field<Gyroscope>(UKF::Vector<3>(0, 0, 0));
+    test_measurement.set_field<Magnetometer>(UKF::FieldVector(1, 0, 0));
     test_measurement.set_field<StaticPressure>(0);
     test_measurement.set_field<DynamicPressure>(0);
 
@@ -620,14 +665,17 @@ TEST(DynamicMeasurementVectorTest, SigmaPointCovariance) {
 
     MyMeasurementVector::CovarianceMatrix expected_covariance(mean_measurement.size(), mean_measurement.size());
 
-    expected_covariance << 5.31709,       0,       0,       0,       0,       0,       0,       0,
-                                 0, 5.31709,       0,       0,       0,       0,       0,       0,
-                                 0,       0, 29.2440,       0,       0,       0,       0,  -4.237,
-                                 0,       0,       0,       1,       0,       0,       0,       0,
-                                 0,       0,       0,       0,       1,       0,       0,       0,
-                                 0,       0,       0,       0,       0,       1,       0,       0,
-                                 0,       0,       0,       0,       0,       0, 1.44e-4,       0,
-                                 0,       0,  -4.237,       0,       0,       0,       0,  32.263;
+    expected_covariance << 5.31709,       0,       0,       0,       0,       0,       0, -2.3059,       0,       0,       0,
+                                 0, 5.31709,       0,       0,       0,       0,       0,       0,       0,       0,       0,
+                                 0,       0, 29.2440,       0,       0,       0,       0,       0,       0,       0,  -4.237,
+                                 0,       0,       0,       1,       0,       0,       0,       0,       0,       0,       0,
+                                 0,       0,       0,       0,       1,       0,       0,       0,       0,       0,       0,
+                                 0,       0,       0,       0,       0,       1,       0,       0,       0,       0,       0,
+                                 0,       0,       0,       0,       0,       0,       0,       0,       0,       0,       0,
+                           -2.3059,       0,       0,       0,       0,       0,       0,       1,       0,       0,       0,
+                                 0,       0,       0,       0,       0,       0,       0,       0,       1,       0,       0,
+                                 0,       0,       0,       0,       0,       0,       0,       0,       0, 1.44e-4,       0,
+                                 0,       0,  -4.237,       0,       0,       0,       0,       0,       0,       0,  32.263;
 
     EXPECT_VECTOR_EQ(expected_covariance.col(0),  calculated_covariance.col(0));
     EXPECT_VECTOR_EQ(expected_covariance.col(1),  calculated_covariance.col(1));
@@ -637,6 +685,9 @@ TEST(DynamicMeasurementVectorTest, SigmaPointCovariance) {
     EXPECT_VECTOR_EQ(expected_covariance.col(5),  calculated_covariance.col(5));
     EXPECT_VECTOR_EQ(expected_covariance.col(6),  calculated_covariance.col(6));
     EXPECT_VECTOR_EQ(expected_covariance.col(7),  calculated_covariance.col(7));
+    EXPECT_VECTOR_EQ(expected_covariance.col(8),  calculated_covariance.col(8));
+    EXPECT_VECTOR_EQ(expected_covariance.col(9),  calculated_covariance.col(9));
+    EXPECT_VECTOR_EQ(expected_covariance.col(10),  calculated_covariance.col(10));
 }
 
 TEST(DynamicMeasurementVectorTest, PartialSigmaPointCovariance) {
@@ -686,19 +737,25 @@ TEST(DynamicMeasurementVectorTest, MeasurementCovariance) {
     MyMeasurementVector::measurement_covariance.set_field<DynamicPressure>(4);
     MyMeasurementVector::measurement_covariance.set_field<Accelerometer>(UKF::Vector<3>(5, 6, 7));
     MyMeasurementVector::measurement_covariance.set_field<StaticPressure>(8);
+    MyMeasurementVector::measurement_covariance.set_field<Magnetometer>(UKF::FieldVector(1, 2, 3));
 
     test_measurement.set_field<Gyroscope>(UKF::Vector<3>(0, 0, 0));
     test_measurement.set_field<DynamicPressure>(0);
     test_measurement.set_field<Accelerometer>(UKF::Vector<3>(0, 0, -9.8));
     test_measurement.set_field<StaticPressure>(101.3);
+    test_measurement.set_field<Magnetometer>(UKF::FieldVector(-1, 0, 1));
 
     expected_measurement.set_field<Gyroscope>(UKF::Vector<3>(0, 0, 0));
     expected_measurement.set_field<DynamicPressure>(0);
     expected_measurement.set_field<Accelerometer>(UKF::Vector<3>(0, 0, -9.8));
     expected_measurement.set_field<StaticPressure>(101.3);
+    expected_measurement.set_field<Magnetometer>(UKF::FieldVector(1, 1, 0));
 
-    MyMeasurementVector::CovarianceMatrix expected_measurement_covariance = MyMeasurementVector::CovarianceMatrix::Zero(8, 8);
-    expected_measurement_covariance.diagonal() << 1, 2, 3, 4, 5, 6, 7, 8;
+    MyMeasurementVector::CovarianceMatrix expected_measurement_covariance = MyMeasurementVector::CovarianceMatrix::Zero(11, 11);
+    expected_measurement_covariance.diagonal() << 1, 2, 3, 4, 5, 6, 7, 8, 0, 0, 0;
+    expected_measurement_covariance.block<3, 3>(8, 8) <<  8, -8,  0,
+                                                         -8,  8,  0,
+                                                          0,  0, 16;
 
     MyMeasurementVector::CovarianceMatrix measurement_covariance =
         test_measurement.calculate_measurement_covariance(expected_measurement);
@@ -711,6 +768,9 @@ TEST(DynamicMeasurementVectorTest, MeasurementCovariance) {
     EXPECT_VECTOR_EQ(expected_measurement_covariance.col(5),  measurement_covariance.col(5));
     EXPECT_VECTOR_EQ(expected_measurement_covariance.col(6),  measurement_covariance.col(6));
     EXPECT_VECTOR_EQ(expected_measurement_covariance.col(7),  measurement_covariance.col(7));
+    EXPECT_VECTOR_EQ(expected_measurement_covariance.col(8),  measurement_covariance.col(8));
+    EXPECT_VECTOR_EQ(expected_measurement_covariance.col(9),  measurement_covariance.col(9));
+    EXPECT_VECTOR_EQ(expected_measurement_covariance.col(10),  measurement_covariance.col(10));
 }
 
 TEST(DynamicMeasurementVectorTest, PartialMeasurementCovariance) {
@@ -720,6 +780,7 @@ TEST(DynamicMeasurementVectorTest, PartialMeasurementCovariance) {
     MyMeasurementVector::measurement_covariance.set_field<DynamicPressure>(4);
     MyMeasurementVector::measurement_covariance.set_field<Accelerometer>(UKF::Vector<3>(5, 6, 7));
     MyMeasurementVector::measurement_covariance.set_field<StaticPressure>(8);
+    MyMeasurementVector::measurement_covariance.set_field<Magnetometer>(UKF::FieldVector(1, 2, 3));
 
     test_measurement.set_field<Gyroscope>(UKF::Vector<3>(0, 0, 0));
 
@@ -746,19 +807,25 @@ TEST(DynamicMeasurementVectorTest, MeasurementRootCovariance) {
     MyMeasurementVector::measurement_root_covariance.set_field<DynamicPressure>(4);
     MyMeasurementVector::measurement_root_covariance.set_field<Accelerometer>(UKF::Vector<3>(5, 6, 7));
     MyMeasurementVector::measurement_root_covariance.set_field<StaticPressure>(8);
+    MyMeasurementVector::measurement_root_covariance.set_field<Magnetometer>(UKF::FieldVector(1, 2, 3));
 
-    test_measurement.set_field<Accelerometer>(UKF::Vector<3>(0, 0, 0));
     test_measurement.set_field<Gyroscope>(UKF::Vector<3>(0, 0, 0));
-    test_measurement.set_field<StaticPressure>(0);
     test_measurement.set_field<DynamicPressure>(0);
+    test_measurement.set_field<Accelerometer>(UKF::Vector<3>(0, 0, 0));
+    test_measurement.set_field<StaticPressure>(0);
+    test_measurement.set_field<Magnetometer>(UKF::FieldVector(-1, 0, 1));
 
     expected_measurement.set_field<Gyroscope>(UKF::Vector<3>(0, 0, 0));
     expected_measurement.set_field<DynamicPressure>(0);
     expected_measurement.set_field<Accelerometer>(UKF::Vector<3>(0, 0, -9.8));
     expected_measurement.set_field<StaticPressure>(101.3);
+    expected_measurement.set_field<Magnetometer>(UKF::FieldVector(1, 1, 0));
 
-    MyMeasurementVector::CovarianceMatrix expected_measurement_root_covariance = MyMeasurementVector::CovarianceMatrix::Zero(8, 8);
-    expected_measurement_root_covariance.diagonal() << 5, 6, 7, 1, 2, 3, 8, 4;
+    MyMeasurementVector::CovarianceMatrix expected_measurement_root_covariance = MyMeasurementVector::CovarianceMatrix::Zero(11, 11);
+    expected_measurement_root_covariance.diagonal() << 1, 2, 3, 4, 5, 6, 7, 8, 0, 0, 0;
+    expected_measurement_root_covariance.block<3, 3>(8, 8) <<  0, -4,  0,
+                                                               0,  4,  0,
+                                                              -2,  0, -6;
 
     MyMeasurementVector::CovarianceMatrix measurement_root_covariance =
         test_measurement.calculate_measurement_root_covariance(expected_measurement);
@@ -771,6 +838,9 @@ TEST(DynamicMeasurementVectorTest, MeasurementRootCovariance) {
     EXPECT_VECTOR_EQ(expected_measurement_root_covariance.col(5),  measurement_root_covariance.col(5));
     EXPECT_VECTOR_EQ(expected_measurement_root_covariance.col(6),  measurement_root_covariance.col(6));
     EXPECT_VECTOR_EQ(expected_measurement_root_covariance.col(7),  measurement_root_covariance.col(7));
+    EXPECT_VECTOR_EQ(expected_measurement_root_covariance.col(8),  measurement_root_covariance.col(8));
+    EXPECT_VECTOR_EQ(expected_measurement_root_covariance.col(9),  measurement_root_covariance.col(9));
+    EXPECT_VECTOR_EQ(expected_measurement_root_covariance.col(10),  measurement_root_covariance.col(10));
 }
 
 TEST(DynamicMeasurementVectorTest, PartialMeasurementRootCovariance) {
@@ -780,6 +850,7 @@ TEST(DynamicMeasurementVectorTest, PartialMeasurementRootCovariance) {
     MyMeasurementVector::measurement_root_covariance.set_field<DynamicPressure>(4);
     MyMeasurementVector::measurement_root_covariance.set_field<Accelerometer>(UKF::Vector<3>(5, 6, 7));
     MyMeasurementVector::measurement_root_covariance.set_field<StaticPressure>(8);
+    MyMeasurementVector::measurement_root_covariance.set_field<Magnetometer>(UKF::FieldVector(1, 2, 3));
 
     test_measurement.set_field<Gyroscope>(UKF::Vector<3>(0, 0, 0));
 

--- a/test/TestDynamicMeasurementVector.cpp
+++ b/test/TestDynamicMeasurementVector.cpp
@@ -680,22 +680,28 @@ template <>
 MyMeasurementVector::CovarianceVector MyMeasurementVector::measurement_covariance = MyMeasurementVector::CovarianceVector();
 
 TEST(DynamicMeasurementVectorTest, MeasurementCovariance) {
-    MyMeasurementVector test_measurement;
+    MyMeasurementVector test_measurement, expected_measurement;
 
     MyMeasurementVector::measurement_covariance.set_field<Gyroscope>(UKF::Vector<3>(1, 2, 3));
     MyMeasurementVector::measurement_covariance.set_field<DynamicPressure>(4);
     MyMeasurementVector::measurement_covariance.set_field<Accelerometer>(UKF::Vector<3>(5, 6, 7));
     MyMeasurementVector::measurement_covariance.set_field<StaticPressure>(8);
 
-    test_measurement.set_field<Accelerometer>(UKF::Vector<3>(0, 0, 0));
     test_measurement.set_field<Gyroscope>(UKF::Vector<3>(0, 0, 0));
-    test_measurement.set_field<StaticPressure>(0);
     test_measurement.set_field<DynamicPressure>(0);
+    test_measurement.set_field<Accelerometer>(UKF::Vector<3>(0, 0, -9.8));
+    test_measurement.set_field<StaticPressure>(101.3);
+
+    expected_measurement.set_field<Gyroscope>(UKF::Vector<3>(0, 0, 0));
+    expected_measurement.set_field<DynamicPressure>(0);
+    expected_measurement.set_field<Accelerometer>(UKF::Vector<3>(0, 0, -9.8));
+    expected_measurement.set_field<StaticPressure>(101.3);
 
     MyMeasurementVector::CovarianceMatrix expected_measurement_covariance = MyMeasurementVector::CovarianceMatrix::Zero(8, 8);
-    expected_measurement_covariance.diagonal() << 5, 6, 7, 1, 2, 3, 8, 4;
+    expected_measurement_covariance.diagonal() << 1, 2, 3, 4, 5, 6, 7, 8;
 
-    MyMeasurementVector::CovarianceMatrix measurement_covariance = test_measurement.calculate_measurement_covariance();
+    MyMeasurementVector::CovarianceMatrix measurement_covariance =
+        test_measurement.calculate_measurement_covariance(expected_measurement);
 
     EXPECT_VECTOR_EQ(expected_measurement_covariance.col(0),  measurement_covariance.col(0));
     EXPECT_VECTOR_EQ(expected_measurement_covariance.col(1),  measurement_covariance.col(1));
@@ -708,7 +714,7 @@ TEST(DynamicMeasurementVectorTest, MeasurementCovariance) {
 }
 
 TEST(DynamicMeasurementVectorTest, PartialMeasurementCovariance) {
-    MyMeasurementVector test_measurement;
+    MyMeasurementVector test_measurement, expected_measurement;
 
     MyMeasurementVector::measurement_covariance.set_field<Gyroscope>(UKF::Vector<3>(1, 2, 3));
     MyMeasurementVector::measurement_covariance.set_field<DynamicPressure>(4);
@@ -717,10 +723,13 @@ TEST(DynamicMeasurementVectorTest, PartialMeasurementCovariance) {
 
     test_measurement.set_field<Gyroscope>(UKF::Vector<3>(0, 0, 0));
 
+    expected_measurement.set_field<Gyroscope>(UKF::Vector<3>(0, 0, 0));
+
     MyMeasurementVector::CovarianceMatrix expected_measurement_covariance = MyMeasurementVector::CovarianceMatrix::Zero(3, 3);
     expected_measurement_covariance.diagonal() << 1, 2, 3;
 
-    MyMeasurementVector::CovarianceMatrix measurement_covariance = test_measurement.calculate_measurement_covariance();
+    MyMeasurementVector::CovarianceMatrix measurement_covariance =
+        test_measurement.calculate_measurement_covariance(expected_measurement);
 
     EXPECT_VECTOR_EQ(expected_measurement_covariance.col(0),  measurement_covariance.col(0));
     EXPECT_VECTOR_EQ(expected_measurement_covariance.col(1),  measurement_covariance.col(1));
@@ -731,7 +740,7 @@ template <>
 MyMeasurementVector::CovarianceVector MyMeasurementVector::measurement_root_covariance = MyMeasurementVector::CovarianceVector();
 
 TEST(DynamicMeasurementVectorTest, MeasurementRootCovariance) {
-    MyMeasurementVector test_measurement;
+    MyMeasurementVector test_measurement, expected_measurement;
 
     MyMeasurementVector::measurement_root_covariance.set_field<Gyroscope>(UKF::Vector<3>(1, 2, 3));
     MyMeasurementVector::measurement_root_covariance.set_field<DynamicPressure>(4);
@@ -743,10 +752,16 @@ TEST(DynamicMeasurementVectorTest, MeasurementRootCovariance) {
     test_measurement.set_field<StaticPressure>(0);
     test_measurement.set_field<DynamicPressure>(0);
 
+    expected_measurement.set_field<Gyroscope>(UKF::Vector<3>(0, 0, 0));
+    expected_measurement.set_field<DynamicPressure>(0);
+    expected_measurement.set_field<Accelerometer>(UKF::Vector<3>(0, 0, -9.8));
+    expected_measurement.set_field<StaticPressure>(101.3);
+
     MyMeasurementVector::CovarianceMatrix expected_measurement_root_covariance = MyMeasurementVector::CovarianceMatrix::Zero(8, 8);
     expected_measurement_root_covariance.diagonal() << 5, 6, 7, 1, 2, 3, 8, 4;
 
-    MyMeasurementVector::CovarianceMatrix measurement_root_covariance = test_measurement.calculate_measurement_root_covariance();
+    MyMeasurementVector::CovarianceMatrix measurement_root_covariance =
+        test_measurement.calculate_measurement_root_covariance(expected_measurement);
 
     EXPECT_VECTOR_EQ(expected_measurement_root_covariance.col(0),  measurement_root_covariance.col(0));
     EXPECT_VECTOR_EQ(expected_measurement_root_covariance.col(1),  measurement_root_covariance.col(1));
@@ -759,7 +774,7 @@ TEST(DynamicMeasurementVectorTest, MeasurementRootCovariance) {
 }
 
 TEST(DynamicMeasurementVectorTest, PartialMeasurementRootCovariance) {
-    MyMeasurementVector test_measurement;
+    MyMeasurementVector test_measurement, expected_measurement;
 
     MyMeasurementVector::measurement_root_covariance.set_field<Gyroscope>(UKF::Vector<3>(1, 2, 3));
     MyMeasurementVector::measurement_root_covariance.set_field<DynamicPressure>(4);
@@ -768,10 +783,13 @@ TEST(DynamicMeasurementVectorTest, PartialMeasurementRootCovariance) {
 
     test_measurement.set_field<Gyroscope>(UKF::Vector<3>(0, 0, 0));
 
+    expected_measurement.set_field<Gyroscope>(UKF::Vector<3>(0, 0, 0));
+
     MyMeasurementVector::CovarianceMatrix expected_measurement_root_covariance = MyMeasurementVector::CovarianceMatrix::Zero(3, 3);
     expected_measurement_root_covariance.diagonal() << 1, 2, 3;
 
-    MyMeasurementVector::CovarianceMatrix measurement_root_covariance = test_measurement.calculate_measurement_root_covariance();
+    MyMeasurementVector::CovarianceMatrix measurement_root_covariance =
+        test_measurement.calculate_measurement_root_covariance(expected_measurement);
 
     EXPECT_VECTOR_EQ(expected_measurement_root_covariance.col(0),  measurement_root_covariance.col(0));
     EXPECT_VECTOR_EQ(expected_measurement_root_covariance.col(1),  measurement_root_covariance.col(1));

--- a/test/TestDynamicMeasurementVector.cpp
+++ b/test/TestDynamicMeasurementVector.cpp
@@ -430,7 +430,7 @@ TEST(DynamicMeasurementVectorTest, SigmaPointMean) {
 
     expected_mean.set_field<Accelerometer>(UKF::Vector<3>(0.0, 0.0, -7.494));
     expected_mean.set_field<Gyroscope>(UKF::Vector<3>(1.0, 0.0, 0.0));
-    expected_mean.set_field<Magnetometer>(UKF::FieldVector(0.344, 0, 0));
+    expected_mean.set_field<Magnetometer>(UKF::FieldVector(0.45, 0, 0));
     expected_mean.set_field<StaticPressure>(89.3);
     expected_mean.set_field<DynamicPressure>(10.4125);
 

--- a/test/TestDynamicMeasurementVector.cpp
+++ b/test/TestDynamicMeasurementVector.cpp
@@ -529,6 +529,66 @@ TEST(DynamicMeasurementVectorTest, PartialSigmaPointDeltas) {
     EXPECT_VECTOR_EQ(target_sigma_point_deltas.col(20), sigma_point_deltas.col(20));
 }
 
+TEST(DynamicMeasurementVectorTest, Innovation) {
+    MyStateVector test_state;
+    MyMeasurementVector test_measurement, target_innovation;
+
+    test_state.set_field<Velocity>(UKF::Vector<3>(10, 0, 0));
+    test_state.set_field<AngularVelocity>(UKF::Vector<3>(0, 0, 1));
+    test_state.set_field<Attitude>(UKF::Quaternion(1, 0, 0, 0));
+    test_state.set_field<Altitude>(1000);
+
+    test_measurement.set_field<Gyroscope>(UKF::Vector<3>(1, 0, 0));
+    test_measurement.set_field<DynamicPressure>(0.5 * 122.5);
+    test_measurement.set_field<Accelerometer>(UKF::Vector<3>(0, 0, 9.8));
+    test_measurement.set_field<StaticPressure>(101.3);
+
+    MyStateVector::CovarianceMatrix covariance = MyStateVector::CovarianceMatrix::Zero();
+    covariance.diagonal() << 1e-9, 1e-9, 1e-9, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0;
+
+    MyStateVector::SigmaPointDistribution sigma_points = test_state.calculate_sigma_point_distribution((covariance *
+        (MyStateVector::covariance_size() + UKF::Parameters::Lambda<MyStateVector>)).llt().matrixL());
+
+    MyMeasurementVector::SigmaPointDistribution<MyStateVector> measurement_sigma_points =
+        test_measurement.calculate_sigma_point_distribution<MyStateVector>(sigma_points);
+
+    MyMeasurementVector mean_measurement = test_measurement.calculate_sigma_point_mean<MyStateVector>(measurement_sigma_points);
+
+    target_innovation.set_field<Gyroscope>(UKF::Vector<3>(1, 0, -1));
+    target_innovation.set_field<DynamicPressure>(0);
+    target_innovation.set_field<Accelerometer>(UKF::Vector<3>(0, 0, 17.294));
+    target_innovation.set_field<StaticPressure>(12.0);
+
+    EXPECT_VECTOR_EQ(target_innovation, mean_measurement.calculate_innovation(test_measurement));
+}
+
+TEST(DynamicMeasurementVectorTest, PartialInnovation) {
+    MyStateVector test_state;
+    MyMeasurementVector test_measurement, target_innovation;
+
+    test_state.set_field<Velocity>(UKF::Vector<3>(10, 0, 0));
+    test_state.set_field<AngularVelocity>(UKF::Vector<3>(0, 0, 1));
+    test_state.set_field<Attitude>(UKF::Quaternion(1, 0, 0, 0));
+    test_state.set_field<Altitude>(1000);
+
+    test_measurement.set_field<Accelerometer>(UKF::Vector<3>(0, 0, 9.8));
+
+    MyStateVector::CovarianceMatrix covariance = MyStateVector::CovarianceMatrix::Zero();
+    covariance.diagonal() << 1e-9, 1e-9, 1e-9, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0;
+
+    MyStateVector::SigmaPointDistribution sigma_points = test_state.calculate_sigma_point_distribution((covariance *
+        (MyStateVector::covariance_size() + UKF::Parameters::Lambda<MyStateVector>)).llt().matrixL());
+
+    MyMeasurementVector::SigmaPointDistribution<MyStateVector> measurement_sigma_points =
+        test_measurement.calculate_sigma_point_distribution<MyStateVector>(sigma_points);
+
+    MyMeasurementVector mean_measurement = test_measurement.calculate_sigma_point_mean<MyStateVector>(measurement_sigma_points);
+
+    target_innovation.set_field<Accelerometer>(UKF::Vector<3>(0, 0, 17.294));
+
+    EXPECT_VECTOR_EQ(target_innovation, mean_measurement.calculate_innovation(test_measurement));
+}
+
 TEST(DynamicMeasurementVectorTest, SigmaPointCovariance) {
     MyStateVector test_state;
     MyMeasurementVector test_measurement;

--- a/test/TestFixedMeasurementVector.cpp
+++ b/test/TestFixedMeasurementVector.cpp
@@ -442,17 +442,28 @@ template <>
 MyMeasurementVector::CovarianceVector MyMeasurementVector::measurement_covariance = MyMeasurementVector::CovarianceVector();
 
 TEST(FixedMeasurementVectorTest, MeasurementCovariance) {
-    MyMeasurementVector test_measurement;
+    MyMeasurementVector test_measurement, expected_measurement;
 
     MyMeasurementVector::measurement_covariance.set_field<Gyroscope>(UKF::Vector<3>(1, 2, 3));
     MyMeasurementVector::measurement_covariance.set_field<DynamicPressure>(4);
     MyMeasurementVector::measurement_covariance.set_field<Accelerometer>(UKF::Vector<3>(5, 6, 7));
     MyMeasurementVector::measurement_covariance.set_field<StaticPressure>(8);
 
+    test_measurement.set_field<Gyroscope>(UKF::Vector<3>(0, 0, 0));
+    test_measurement.set_field<DynamicPressure>(0);
+    test_measurement.set_field<Accelerometer>(UKF::Vector<3>(0, 0, -9.8));
+    test_measurement.set_field<StaticPressure>(101.3);
+
+    expected_measurement.set_field<Gyroscope>(UKF::Vector<3>(0, 0, 0));
+    expected_measurement.set_field<DynamicPressure>(0);
+    expected_measurement.set_field<Accelerometer>(UKF::Vector<3>(0, 0, -9.8));
+    expected_measurement.set_field<StaticPressure>(101.3);
+
     MyMeasurementVector::CovarianceMatrix expected_measurement_covariance = MyMeasurementVector::CovarianceMatrix::Zero();
     expected_measurement_covariance.diagonal() << 5, 6, 7, 1, 2, 3, 8, 4;
 
-    MyMeasurementVector::CovarianceMatrix measurement_covariance = test_measurement.calculate_measurement_covariance();
+    MyMeasurementVector::CovarianceMatrix measurement_covariance =
+        test_measurement.calculate_measurement_covariance(expected_measurement);
 
     EXPECT_VECTOR_EQ(expected_measurement_covariance.col(0),  measurement_covariance.col(0));
     EXPECT_VECTOR_EQ(expected_measurement_covariance.col(1),  measurement_covariance.col(1));
@@ -468,17 +479,28 @@ template <>
 MyMeasurementVector::CovarianceVector MyMeasurementVector::measurement_root_covariance = MyMeasurementVector::CovarianceVector();
 
 TEST(FixedMeasurementVectorTest, MeasurementRootCovariance) {
-    MyMeasurementVector test_measurement;
+    MyMeasurementVector test_measurement, expected_measurement;
 
     MyMeasurementVector::measurement_root_covariance.set_field<Gyroscope>(UKF::Vector<3>(1, 2, 3));
     MyMeasurementVector::measurement_root_covariance.set_field<DynamicPressure>(4);
     MyMeasurementVector::measurement_root_covariance.set_field<Accelerometer>(UKF::Vector<3>(5, 6, 7));
     MyMeasurementVector::measurement_root_covariance.set_field<StaticPressure>(8);
 
+    test_measurement.set_field<Gyroscope>(UKF::Vector<3>(0, 0, 0));
+    test_measurement.set_field<DynamicPressure>(0);
+    test_measurement.set_field<Accelerometer>(UKF::Vector<3>(0, 0, -9.8));
+    test_measurement.set_field<StaticPressure>(101.3);
+
+    expected_measurement.set_field<Gyroscope>(UKF::Vector<3>(0, 0, 0));
+    expected_measurement.set_field<DynamicPressure>(0);
+    expected_measurement.set_field<Accelerometer>(UKF::Vector<3>(0, 0, -9.8));
+    expected_measurement.set_field<StaticPressure>(101.3);
+
     MyMeasurementVector::CovarianceMatrix expected_measurement_root_covariance = MyMeasurementVector::CovarianceMatrix::Zero();
     expected_measurement_root_covariance.diagonal() << 5, 6, 7, 1, 2, 3, 8, 4;
 
-    MyMeasurementVector::CovarianceMatrix measurement_root_covariance = test_measurement.calculate_measurement_root_covariance();
+    MyMeasurementVector::CovarianceMatrix measurement_root_covariance =
+        test_measurement.calculate_measurement_root_covariance(expected_measurement);
 
     EXPECT_VECTOR_EQ(expected_measurement_root_covariance.col(0),  measurement_root_covariance.col(0));
     EXPECT_VECTOR_EQ(expected_measurement_root_covariance.col(1),  measurement_root_covariance.col(1));

--- a/test/TestFixedMeasurementVector.cpp
+++ b/test/TestFixedMeasurementVector.cpp
@@ -331,7 +331,7 @@ TEST(FixedMeasurementVectorTest, SigmaPointMean) {
 
     MyMeasurementVector expected_mean;
 
-    expected_mean << 0.0, 0.0, -7.494, 1, 0, 0, 0.344, 0, 0, 89.3, 10.4125;
+    expected_mean << 0.0, 0.0, -7.494, 1, 0, 0, 0.45, 0, 0, 89.3, 10.4125;
 
     EXPECT_VECTOR_EQ(expected_mean, test_measurement.calculate_sigma_point_mean<MyStateVector>(measurement_sigma_points));
 }

--- a/test/TestFixedMeasurementVector.cpp
+++ b/test/TestFixedMeasurementVector.cpp
@@ -511,3 +511,120 @@ TEST(FixedMeasurementVectorTest, MeasurementRootCovariance) {
     EXPECT_VECTOR_EQ(expected_measurement_root_covariance.col(6),  measurement_root_covariance.col(6));
     EXPECT_VECTOR_EQ(expected_measurement_root_covariance.col(7),  measurement_root_covariance.col(7));
 }
+
+TEST(FixedMeasurementVectorTest, CalculateRotationVector) {
+    UKF::Vector<3> test;
+
+    test = UKF::Detail::calculate_rotation_vector<MyMeasurementVector>(UKF::Vector<3>(0, 0, 0), UKF::Vector<3>(0, 0, 0));
+    EXPECT_VECTOR_EQ(UKF::Vector<3>(0, 0, 0), test);
+
+    test = UKF::Detail::calculate_rotation_vector<MyMeasurementVector>(UKF::Vector<3>(1, 0, 0), UKF::Vector<3>(0, 0, 0));
+    EXPECT_VECTOR_EQ(UKF::Vector<3>(0, 0, 0), test);
+
+    test = UKF::Detail::calculate_rotation_vector<MyMeasurementVector>(UKF::Vector<3>(0, 0, 0), UKF::Vector<3>(1, 0, 0));
+    EXPECT_VECTOR_EQ(UKF::Vector<3>(0, 0, 0), test);
+
+    test = UKF::Detail::calculate_rotation_vector<MyMeasurementVector>(UKF::Vector<3>(1, 0, 0), UKF::Vector<3>(1, 0, 0));
+    EXPECT_VECTOR_EQ(UKF::Vector<3>(0, 0, 0), test);
+
+    test = UKF::Detail::calculate_rotation_vector<MyMeasurementVector>(UKF::Vector<3>(1, 0, 0), UKF::Vector<3>(-1, 0, 0));
+    EXPECT_VECTOR_EQ(UKF::Vector<3>(0, 0, -2/std::numeric_limits<real_t>::epsilon()), test);
+
+    test = UKF::Detail::calculate_rotation_vector<MyMeasurementVector>(UKF::Vector<3>(1, 0, 0), UKF::Vector<3>(0, 1, 0));
+    EXPECT_VECTOR_EQ(UKF::Vector<3>(0, 0, -2), test);
+
+    test = UKF::Detail::calculate_rotation_vector<MyMeasurementVector>(UKF::Vector<3>(1, 0, 0), UKF::Vector<3>(0, -1, 0));
+    EXPECT_VECTOR_EQ(UKF::Vector<3>(0, 0, 2), test);
+
+    test = UKF::Detail::calculate_rotation_vector<MyMeasurementVector>(UKF::Vector<3>(1, 0, 0), UKF::Vector<3>(0, 0, 1));
+    EXPECT_VECTOR_EQ(UKF::Vector<3>(0, 2, 0), test);
+
+    test = UKF::Detail::calculate_rotation_vector<MyMeasurementVector>(UKF::Vector<3>(1, 0, 0), UKF::Vector<3>(0, 0, -1));
+    EXPECT_VECTOR_EQ(UKF::Vector<3>(0, -2, 0), test);
+
+    /* Some random vectors, for the a = 0, f = 2 case. */
+    test = UKF::Detail::calculate_rotation_vector<MyMeasurementVector>(
+        UKF::Vector<3>(5.0746, -2.3911, 1.3564), UKF::Vector<3>(8.3439, -4.2832, 5.1440));
+    EXPECT_VECTOR_EQ(UKF::Vector<3>(0.1070, 0.2438, 0.0294), test);
+
+    test = UKF::Detail::calculate_rotation_vector<MyMeasurementVector>(
+        UKF::Vector<3>(5.5833, 8.6802, -7.4019), UKF::Vector<3>(-8.4829, -8.9210, 0.6160));
+    EXPECT_VECTOR_EQ(UKF::Vector<3>(4.4643, -4.3661, -1.7527), test);
+
+    test = UKF::Detail::calculate_rotation_vector<MyMeasurementVector>(
+        UKF::Vector<3>(2.0396, -4.7406, 3.0816), UKF::Vector<3>(-3.7757, 0.5707, -6.6870));
+    EXPECT_VECTOR_EQ(UKF::Vector<3>(-3.9209, -0.2624, 2.1914), test);
+}
+
+TEST(FixedMeasurementVectorTest, CalculateRotationVectorJacobian) {
+    UKF::Matrix<3, 3> test;
+
+    test = UKF::Detail::calculate_rotation_vector_jacobian<MyMeasurementVector>(UKF::Vector<3>(0, 0, 0), UKF::Vector<3>(0, 0, 0));
+    EXPECT_VECTOR_EQ(UKF::Vector<3>(0, 0, 0).transpose(), (test*test.transpose()).row(0));
+    EXPECT_VECTOR_EQ(UKF::Vector<3>(0, 0, 0).transpose(), (test*test.transpose()).row(1));
+    EXPECT_VECTOR_EQ(UKF::Vector<3>(0, 0, 0).transpose(), (test*test.transpose()).row(2));
+
+    test = UKF::Detail::calculate_rotation_vector_jacobian<MyMeasurementVector>(UKF::Vector<3>(1, 0, 0), UKF::Vector<3>(0, 0, 0));
+    EXPECT_VECTOR_EQ(UKF::Vector<3>(0, 0, 0).transpose(), (test*test.transpose()).row(0));
+    EXPECT_VECTOR_EQ(UKF::Vector<3>(0, 0, 0).transpose(), (test*test.transpose()).row(1));
+    EXPECT_VECTOR_EQ(UKF::Vector<3>(0, 0, 0).transpose(), (test*test.transpose()).row(2));
+
+    test = UKF::Detail::calculate_rotation_vector_jacobian<MyMeasurementVector>(UKF::Vector<3>(0, 0, 0), UKF::Vector<3>(1, 0, 0));
+    EXPECT_VECTOR_EQ(UKF::Vector<3>(0, 0, 0).transpose(), (test*test.transpose()).row(0));
+    EXPECT_VECTOR_EQ(UKF::Vector<3>(0, 4/(std::numeric_limits<real_t>::epsilon()*std::numeric_limits<real_t>::epsilon()), 0).transpose(),
+            (test*test.transpose()).row(1));
+    EXPECT_VECTOR_EQ(UKF::Vector<3>(0, 0, 4/(std::numeric_limits<real_t>::epsilon()*std::numeric_limits<real_t>::epsilon())).transpose(),
+            (test*test.transpose()).row(2));
+
+    test = UKF::Detail::calculate_rotation_vector_jacobian<MyMeasurementVector>(UKF::Vector<3>(1, 0, 0), UKF::Vector<3>(1, 0, 0));
+    EXPECT_VECTOR_EQ(UKF::Vector<3>(0, 0, 0).transpose(), (test*test.transpose()).row(0));
+    EXPECT_VECTOR_EQ(UKF::Vector<3>(0, 1, 0).transpose(), (test*test.transpose()).row(1));
+    EXPECT_VECTOR_EQ(UKF::Vector<3>(0, 0, 1).transpose(), (test*test.transpose()).row(2));
+
+    test = UKF::Detail::calculate_rotation_vector_jacobian<MyMeasurementVector>(UKF::Vector<3>(1, 0, 0), UKF::Vector<3>(-1, 0, 0));
+    EXPECT_VECTOR_EQ(UKF::Vector<3>(0, 0, 0).transpose(), (test*test.transpose()).row(0));
+    EXPECT_VECTOR_EQ(UKF::Vector<3>(0, 4/(std::numeric_limits<real_t>::epsilon()*std::numeric_limits<real_t>::epsilon()), 0).transpose(),
+            (test*test.transpose()).row(1));
+    EXPECT_VECTOR_EQ(UKF::Vector<3>(0, 0, 4/(std::numeric_limits<real_t>::epsilon()*std::numeric_limits<real_t>::epsilon())).transpose(),
+            (test*test.transpose()).row(2));
+
+    test = UKF::Detail::calculate_rotation_vector_jacobian<MyMeasurementVector>(UKF::Vector<3>(1, 0, 0), UKF::Vector<3>(0, 1, 0));
+    EXPECT_VECTOR_EQ(UKF::Vector<3>(4, 0, 0).transpose(), (test*test.transpose()).row(0));
+    EXPECT_VECTOR_EQ(UKF::Vector<3>(0, 0, 0).transpose(), (test*test.transpose()).row(1));
+    EXPECT_VECTOR_EQ(UKF::Vector<3>(0, 0, 4).transpose(), (test*test.transpose()).row(2));
+
+    test = UKF::Detail::calculate_rotation_vector_jacobian<MyMeasurementVector>(UKF::Vector<3>(1, 0, 0), UKF::Vector<3>(0, -1, 0));
+    EXPECT_VECTOR_EQ(UKF::Vector<3>(4, 0, 0).transpose(), (test*test.transpose()).row(0));
+    EXPECT_VECTOR_EQ(UKF::Vector<3>(0, 0, 0).transpose(), (test*test.transpose()).row(1));
+    EXPECT_VECTOR_EQ(UKF::Vector<3>(0, 0, 4).transpose(), (test*test.transpose()).row(2));
+
+    test = UKF::Detail::calculate_rotation_vector_jacobian<MyMeasurementVector>(UKF::Vector<3>(1, 0, 0), UKF::Vector<3>(0, 0, 1));
+    EXPECT_VECTOR_EQ(UKF::Vector<3>(4, 0, 0).transpose(), (test*test.transpose()).row(0));
+    EXPECT_VECTOR_EQ(UKF::Vector<3>(0, 4, 0).transpose(), (test*test.transpose()).row(1));
+    EXPECT_VECTOR_EQ(UKF::Vector<3>(0, 0, 0).transpose(), (test*test.transpose()).row(2));
+
+    test = UKF::Detail::calculate_rotation_vector_jacobian<MyMeasurementVector>(UKF::Vector<3>(1, 0, 0), UKF::Vector<3>(0, 0, -1));
+    EXPECT_VECTOR_EQ(UKF::Vector<3>(4, 0, 0).transpose(), (test*test.transpose()).row(0));
+    EXPECT_VECTOR_EQ(UKF::Vector<3>(0, 4, 0).transpose(), (test*test.transpose()).row(1));
+    EXPECT_VECTOR_EQ(UKF::Vector<3>(0, 0, 0).transpose(), (test*test.transpose()).row(2));
+
+    /* Some random vectors, for the a = 0, f = 2 case. */
+    Eigen::DiagonalMatrix<real_t, 3> c(UKF::Vector<3>(1, 2, 3));
+    test = UKF::Detail::calculate_rotation_vector_jacobian<MyMeasurementVector>(
+        UKF::Vector<3>(5.0746, -2.3911, 1.3564), UKF::Vector<3>(8.3439, -4.2832, 5.1440));
+    EXPECT_VECTOR_EQ(UKF::Vector<3>( 0.030105,  0.032038, -0.022155).transpose(), (test*c*test.transpose()).row(0));
+    EXPECT_VECTOR_EQ(UKF::Vector<3>( 0.032038,  0.073227,  0.009005).transpose(), (test*c*test.transpose()).row(1));
+    EXPECT_VECTOR_EQ(UKF::Vector<3>(-0.022155,  0.009005,  0.043436).transpose(), (test*c*test.transpose()).row(2));
+
+    test = UKF::Detail::calculate_rotation_vector_jacobian<MyMeasurementVector>(
+        UKF::Vector<3>(5.5833, 8.6802, -7.4019), UKF::Vector<3>(-8.4829, -8.9210, 0.6160));
+    EXPECT_VECTOR_EQ(UKF::Vector<3>( 0.790494, -0.776049, -0.353005).transpose(), (test*c*test.transpose()).row(0));
+    EXPECT_VECTOR_EQ(UKF::Vector<3>(-0.776049,  0.768788,  0.446778).transpose(), (test*c*test.transpose()).row(1));
+    EXPECT_VECTOR_EQ(UKF::Vector<3>(-0.353005,  0.446778,  1.609094).transpose(), (test*c*test.transpose()).row(2));
+
+    test = UKF::Detail::calculate_rotation_vector_jacobian<MyMeasurementVector>(
+        UKF::Vector<3>(2.0396, -4.7406, 3.0816), UKF::Vector<3>(-3.7757, 0.5707, -6.6870));
+    EXPECT_VECTOR_EQ(UKF::Vector<3>( 1.850606, -0.474603, -1.085418).transpose(), (test*c*test.transpose()).row(0));
+    EXPECT_VECTOR_EQ(UKF::Vector<3>(-0.474603,  1.420474,  0.389206).transpose(), (test*c*test.transpose()).row(1));
+    EXPECT_VECTOR_EQ(UKF::Vector<3>(-1.085418,  0.389206,  0.646079).transpose(), (test*c*test.transpose()).row(2));
+}

--- a/test/TestFixedMeasurementVector.cpp
+++ b/test/TestFixedMeasurementVector.cpp
@@ -10,12 +10,14 @@ enum MyFields {
     StaticPressure,
     DynamicPressure,
     Accelerometer,
-    Gyroscope
+    Gyroscope,
+    Magnetometer
 };
 
 using MyMeasurementVector = UKF::FixedMeasurementVector<
     UKF::Field<Accelerometer, UKF::Vector<3>>,
     UKF::Field<Gyroscope, UKF::Vector<3>>,
+    UKF::Field<Magnetometer, UKF::FieldVector>,
     UKF::Field<StaticPressure, real_t>,
     UKF::Field<DynamicPressure, real_t>
 >;
@@ -23,8 +25,8 @@ using MyMeasurementVector = UKF::FixedMeasurementVector<
 TEST(FixedMeasurementVectorTest, Instantiation) {
     MyMeasurementVector test_measurement;
 
-    EXPECT_EQ(8, MyMeasurementVector::MaxRowsAtCompileTime);
-    EXPECT_EQ(8, test_measurement.size());
+    EXPECT_EQ(11, MyMeasurementVector::MaxRowsAtCompileTime);
+    EXPECT_EQ(11, test_measurement.size());
 }
 
 TEST(FixedMeasurementVectorTest, Assignment) {
@@ -34,16 +36,18 @@ TEST(FixedMeasurementVectorTest, Assignment) {
     test_measurement.set_field<DynamicPressure>(4);
     test_measurement.set_field<Accelerometer>(UKF::Vector<3>(5, 6, 7));
     test_measurement.set_field<StaticPressure>(8);
+    test_measurement.set_field<Magnetometer>(UKF::FieldVector(9, 10, 11));
 
-    EXPECT_EQ(8, test_measurement.size());
+    EXPECT_EQ(11, test_measurement.size());
 
     EXPECT_EQ(8, test_measurement.get_field<StaticPressure>());
     EXPECT_EQ(4, test_measurement.get_field<DynamicPressure>());
     EXPECT_VECTOR_EQ(UKF::Vector<3>(1, 2, 3), test_measurement.get_field<Gyroscope>());
     EXPECT_VECTOR_EQ(UKF::Vector<3>(5, 6, 7), test_measurement.get_field<Accelerometer>());
+    EXPECT_VECTOR_EQ(UKF::FieldVector(9, 10, 11), test_measurement.get_field<Magnetometer>());
 
-    UKF::Vector<8> expected;
-    expected << 5, 6, 7, 1, 2, 3, 8, 4;
+    UKF::Vector<11> expected;
+    expected << 5, 6, 7, 1, 2, 3, 9, 10, 11, 8, 4;
     EXPECT_VECTOR_EQ(expected, test_measurement);
 }
 
@@ -54,17 +58,18 @@ TEST(FixedMeasurementVectorTest, Reassignment) {
     test_measurement.set_field<DynamicPressure>(4);
     test_measurement.set_field<Accelerometer>(UKF::Vector<3>(5, 6, 7));
     test_measurement.set_field<StaticPressure>(8);
+    test_measurement.set_field<Magnetometer>(UKF::FieldVector(9, 10, 11));
 
-    EXPECT_EQ(8, test_measurement.size());
+    EXPECT_EQ(11, test_measurement.size());
     EXPECT_VECTOR_EQ(UKF::Vector<3>(1, 2, 3), test_measurement.get_field<Gyroscope>());
 
     test_measurement.set_field<Gyroscope>(UKF::Vector<3>(4, 5, 6));
 
-    EXPECT_EQ(8, test_measurement.size());
+    EXPECT_EQ(11, test_measurement.size());
     EXPECT_VECTOR_EQ(UKF::Vector<3>(4, 5, 6), test_measurement.get_field<Gyroscope>());
 
-    UKF::Vector<8> expected;
-    expected << 5, 6, 7, 4, 5, 6, 8, 4;
+    UKF::Vector<11> expected;
+    expected << 5, 6, 7, 4, 5, 6, 9, 10, 11, 8, 4;
     EXPECT_VECTOR_EQ(expected, test_measurement);
 }
 
@@ -75,43 +80,47 @@ TEST(FixedMeasurementVectorTest, MultipleReassignment) {
     test_measurement.set_field<DynamicPressure>(4);
     test_measurement.set_field<Accelerometer>(UKF::Vector<3>(5, 6, 7));
     test_measurement.set_field<StaticPressure>(8);
+    test_measurement.set_field<Magnetometer>(UKF::FieldVector(9, 10, 11));
 
-    EXPECT_EQ(8, test_measurement.size());
-    UKF::Vector<8> expected;
-    expected << 5, 6, 7, 1, 2, 3, 8, 4;
+    EXPECT_EQ(11, test_measurement.size());
+    UKF::Vector<11> expected;
+    expected << 5, 6, 7, 1, 2, 3, 9, 10, 11, 8, 4;
     EXPECT_VECTOR_EQ(expected, test_measurement);
 
     test_measurement.set_field<Gyroscope>(UKF::Vector<3>(4, 5, 6));
 
-    EXPECT_EQ(8, test_measurement.size());
+    EXPECT_EQ(11, test_measurement.size());
     EXPECT_VECTOR_EQ(UKF::Vector<3>(4, 5, 6), test_measurement.get_field<Gyroscope>());
-    expected << 5, 6, 7, 4, 5, 6, 8, 4;
+    expected << 5, 6, 7, 4, 5, 6, 9, 10, 11, 8, 4;
     EXPECT_VECTOR_EQ(expected, test_measurement);
 
     test_measurement.set_field<Accelerometer>(UKF::Vector<3>(7, 8, 9));
 
-    EXPECT_EQ(8, test_measurement.size());
+    EXPECT_EQ(11, test_measurement.size());
     EXPECT_VECTOR_EQ(UKF::Vector<3>(7, 8, 9), test_measurement.get_field<Accelerometer>());
-    expected << 7, 8, 9, 4, 5, 6, 8, 4;
+    expected << 7, 8, 9, 4, 5, 6, 9, 10, 11, 8, 4;
     EXPECT_VECTOR_EQ(expected, test_measurement);
 
     test_measurement.set_field<DynamicPressure>(1);
 
-    EXPECT_EQ(8, test_measurement.size());
+    EXPECT_EQ(11, test_measurement.size());
     EXPECT_EQ(1, test_measurement.get_field<DynamicPressure>());
-    expected << 7, 8, 9, 4, 5, 6, 8, 1;
+    expected << 7, 8, 9, 4, 5, 6, 9, 10, 11, 8, 1;
     EXPECT_VECTOR_EQ(expected, test_measurement);
 
     test_measurement.set_field<StaticPressure>(3);
 
-    EXPECT_EQ(8, test_measurement.size());
+    EXPECT_EQ(11, test_measurement.size());
     EXPECT_EQ(3, test_measurement.get_field<StaticPressure>());
-    expected << 7, 8, 9, 4, 5, 6, 3, 1;
+    expected << 7, 8, 9, 4, 5, 6, 9, 10, 11, 3, 1;
     EXPECT_VECTOR_EQ(expected, test_measurement);
-}
 
-TEST(FixedMeasurementVectorTest, Arithmetic) {
-    
+    test_measurement.set_field<Magnetometer>(UKF::FieldVector(1, 2, 3));
+
+    EXPECT_EQ(11, test_measurement.size());
+    EXPECT_VECTOR_EQ(UKF::Vector<3>(1, 2, 3), test_measurement.get_field<Magnetometer>());
+    expected << 7, 8, 9, 4, 5, 6, 1, 2, 3, 3, 1;
+    EXPECT_VECTOR_EQ(expected, test_measurement);
 }
 
 enum MyStateVectorFields {
@@ -156,6 +165,12 @@ real_t MyMeasurementVector::expected_measurement
     return 0.5 * 1.225 * state.get_field<Velocity>().squaredNorm();
 }
 
+template <> template <>
+UKF::FieldVector MyMeasurementVector::expected_measurement
+<MyStateVector, Magnetometer>(const MyStateVector& state) {
+    return state.get_field<Attitude>() * UKF::FieldVector(0.45, 0, 0);
+}
+
 /*
 These versions of the predicted measurement functions have non-state inputs.
 This could be used to add predicted kinematic acceleration by feeding control
@@ -185,6 +200,12 @@ real_t MyMeasurementVector::expected_measurement
     return 0.5 * 1.225 * state.get_field<Velocity>().squaredNorm();
 }
 
+template <> template <>
+UKF::FieldVector MyMeasurementVector::expected_measurement
+<MyStateVector, Magnetometer, UKF::Vector<3>>(const MyStateVector& state, const UKF::Vector<3>& input) {
+    return state.get_field<Attitude>() * UKF::FieldVector(0.45, 0, 0) + input;
+}
+
 TEST(FixedMeasurementVectorTest, SigmaPointGeneration) {
     MyStateVector test_state;
     MyMeasurementVector test_measurement;
@@ -208,6 +229,9 @@ TEST(FixedMeasurementVectorTest, SigmaPointGeneration) {
                             1,      1,      1,      1,  4.606,      1,      1,      1,      1,      1,      1,      1,      1,      1, -2.606,      1,      1,      1,      1,      1,      1,
                             0,      0,      0,      0,      0,  3.606,      0,      0,      0,      0,      0,      0,      0,      0,      0, -3.606,      0,      0,      0,      0,      0,
                             0,      0,      0,      0,      0,      0,  3.606,      0,      0,      0,      0,      0,      0,      0,      0,      0, -3.606,      0,      0,      0,      0,
+                         0.45,   0.45,   0.45,   0.45,   0.45,   0.45,   0.45,   0.45, -0.238, -0.238,   0.45,   0.45,   0.45,   0.45,   0.45,   0.45,   0.45,   0.45, -0.238, -0.238,   0.45,
+                            0,      0,      0,      0,      0,      0,      0,      0,      0,  0.382,      0,      0,      0,      0,      0,      0,      0,      0,      0, -0.382,      0,
+                            0,      0,      0,      0,      0,      0,      0,      0, -0.382,      0,      0,      0,      0,      0,      0,      0,      0,      0,  0.382,      0,      0,
                          89.3,   89.3,   89.3,   89.3,   89.3,   89.3,   89.3,   89.3,   89.3,   89.3, 89.257,   89.3,   89.3,   89.3,   89.3,   89.3,   89.3,   89.3,   89.3,   89.3, 89.343,
                         8.575, 20.954, 25.371, 29.788,  8.575,  8.575,  8.575,  8.575,  8.575,  8.575,  8.575, 12.121,  7.704,  3.287,  8.575,  8.575,  8.575,  8.575,  8.575,  8.575,  8.575;
     measurement_sigma_points = test_measurement.calculate_sigma_point_distribution<MyStateVector>(sigma_points);
@@ -258,6 +282,9 @@ TEST(FixedMeasurementVectorTest, SigmaPointGenerationWithInput) {
                             1,      1,      1,      1,  4.606,      1,      1,      1,      1,      1,      1,      1,      1,      1, -2.606,      1,      1,      1,      1,      1,      1,
                             0,      0,      0,      0,      0,  3.606,      0,      0,      0,      0,      0,      0,      0,      0,      0, -3.606,      0,      0,      0,      0,      0,
                             0,      0,      0,      0,      0,      0,  3.606,      0,      0,      0,      0,      0,      0,      0,      0,      0, -3.606,      0,      0,      0,      0,
+                         1.45,   1.45,   1.45,   1.45,   1.45,   1.45,   1.45,   1.45,  0.762,  0.762,   1.45,   1.45,   1.45,   1.45,   1.45,   1.45,   1.45,   1.45,  0.762,  0.762,   1.45,
+                            2,      2,      2,      2,      2,      2,      2,      2,      2,  2.382,      2,      2,      2,      2,      2,      2,      2,      2,      2,  1.618,      2,
+                            3,      3,      3,      3,      3,      3,      3,      3,  2.618,      3,      3,      3,      3,      3,      3,      3,      3,      3,  3.382,      3,      3,
                          89.3,   89.3,   89.3,   89.3,   89.3,   89.3,   89.3,   89.3,   89.3,   89.3, 89.257,   89.3,   89.3,   89.3,   89.3,   89.3,   89.3,   89.3,   89.3,   89.3, 89.343,
                         8.575, 20.954, 25.371, 29.788,  8.575,  8.575,  8.575,  8.575,  8.575,  8.575,  8.575, 12.121,  7.704,  3.287,  8.575,  8.575,  8.575,  8.575,  8.575,  8.575,  8.575;
     measurement_sigma_points = test_measurement.calculate_sigma_point_distribution<MyStateVector>(
@@ -296,12 +323,15 @@ TEST(FixedMeasurementVectorTest, SigmaPointMean) {
                                  1,      1,      1,      1,  4.606,      1,      1,      1,      1,      1,      1,      1,      1,      1, -2.606,      1,      1,      1,      1,      1,      1,
                                  0,      0,      0,      0,      0,  3.606,      0,      0,      0,      0,      0,      0,      0,      0,      0, -3.606,      0,      0,      0,      0,      0,
                                  0,      0,      0,      0,      0,      0,  3.606,      0,      0,      0,      0,      0,      0,      0,      0,      0, -3.606,      0,      0,      0,      0,
+                              0.45,   0.45,   0.45,   0.45,   0.45,   0.45,   0.45,   0.45, -0.238, -0.238,   0.45,   0.45,   0.45,   0.45,   0.45,   0.45,   0.45,   0.45, -0.238, -0.238,   0.45,
+                                 0,      0,      0,      0,      0,      0,      0,      0,      0,  0.382,      0,      0,      0,      0,      0,      0,      0,      0,      0, -0.382,      0,
+                                 0,      0,      0,      0,      0,      0,      0,      0, -0.382,      0,      0,      0,      0,      0,      0,      0,      0,      0,  0.382,      0,      0,
                               89.3,   89.3,   89.3,   89.3,   89.3,   89.3,   89.3,   89.3,   89.3,   89.3, 89.257,   89.3,   89.3,   89.3,   89.3,   89.3,   89.3,   89.3,   89.3,   89.3, 89.343,
                              8.575, 20.954, 25.371, 29.788,  8.575,  8.575,  8.575,  8.575,  8.575,  8.575,  8.575, 12.121,  7.704,  3.287,  8.575,  8.575,  8.575,  8.575,  8.575,  8.575,  8.575;
 
     MyMeasurementVector expected_mean;
 
-    expected_mean << 0.0, 0.0, -7.494,  1,  0,  0,  89.3,  10.4125;
+    expected_mean << 0.0, 0.0, -7.494, 1, 0, 0, 0.344, 0, 0, 89.3, 10.4125;
 
     EXPECT_VECTOR_EQ(expected_mean, test_measurement.calculate_sigma_point_mean<MyStateVector>(measurement_sigma_points));
 }
@@ -309,6 +339,8 @@ TEST(FixedMeasurementVectorTest, SigmaPointMean) {
 TEST(FixedMeasurementVectorTest, SigmaPointDeltas) {
     MyStateVector test_state;
     MyMeasurementVector test_measurement;
+
+    test_measurement.set_field<Magnetometer>(UKF::FieldVector(1, 0, 0));
 
     test_state.set_field<Velocity>(UKF::Vector<3>(1, 2, 3));
     test_state.set_field<AngularVelocity>(UKF::Vector<3>(1, 0, 0));
@@ -327,14 +359,17 @@ TEST(FixedMeasurementVectorTest, SigmaPointDeltas) {
     MyMeasurementVector mean_measurement = test_measurement.calculate_sigma_point_mean<MyStateVector>(measurement_sigma_points);
     MyMeasurementVector::SigmaPointDeltas<MyStateVector> sigma_point_deltas, target_sigma_point_deltas;
 
-    target_sigma_point_deltas <<       0,       0,       0,       0,       0,       0,       0,       0,  -8.314,       0,       0,      0,       0,       0,       0,       0,       0,       0,   8.314,       0,       0,
-                                       0,       0,       0,       0,       0,       0,       0,   8.314,       0,       0,       0,      0,       0,       0,       0,       0,       0,  -8.314,       0,       0,       0,
-                                  -2.306,  -2.306,  -2.306,  -2.306,  -2.306,  -2.306,  -2.306,  12.682,  12.682,  -2.306,  -2.306, -2.306,  -2.306,  -2.306,  -2.306,  -2.306,  -2.306,  12.682,  12.682,  -2.306,  -2.306,
-                                       0,       0,       0,       0,   3.606,       0,       0,       0,       0,       0,       0,      0,       0,       0,  -3.606,       0,       0,       0,       0,       0,       0,
-                                       0,       0,       0,       0,       0,   3.606,       0,       0,       0,       0,       0,      0,       0,       0,       0,  -3.606,       0,       0,       0,       0,       0,
-                                       0,       0,       0,       0,       0,       0,   3.606,       0,       0,       0,       0,      0,       0,       0,       0,       0,  -3.606,       0,       0,       0,       0,
-                                       0,       0,       0,       0,       0,       0,       0,       0,       0,       0,  -0.043,      0,       0,       0,       0,       0,       0,       0,       0,       0,   0.043,
-                                 -1.8375,  10.542,  14.959,  19.376, -1.8375, -1.8375, -1.8375, -1.8375, -1.8375, -1.8375, -1.8375, 1.7082, -2.7086,  -7.126, -1.8375, -1.8375, -1.8375, -1.8375, -1.8375, -1.8375, -1.8375;
+    target_sigma_point_deltas <<       0,       0,       0,       0,       0,       0,       0,       0,  -8.314,       0,       0,       0,       0,       0,       0,       0,       0,       0,   8.314,       0,       0,
+                                       0,       0,       0,       0,       0,       0,       0,   8.314,       0,       0,       0,       0,       0,       0,       0,       0,       0,  -8.314,       0,       0,       0,
+                                  -2.306,  -2.306,  -2.306,  -2.306,  -2.306,  -2.306,  -2.306,  12.682,  12.682,  -2.306,  -2.306,  -2.306,  -2.306,  -2.306,  -2.306,  -2.306,  -2.306,  12.682,  12.682,  -2.306,  -2.306,
+                                       0,       0,       0,       0,   3.606,       0,       0,       0,       0,       0,       0,       0,       0,       0,  -3.606,       0,       0,       0,       0,       0,       0,
+                                       0,       0,       0,       0,       0,   3.606,       0,       0,       0,       0,       0,       0,       0,       0,       0,  -3.606,       0,       0,       0,       0,       0,
+                                       0,       0,       0,       0,       0,       0,   3.606,       0,       0,       0,       0,       0,       0,       0,       0,       0,  -3.606,       0,       0,       0,       0,
+                                       0,       0,       0,       0,       0,       0,       0,       0,       0,       0,       0,       0,       0,       0,       0,       0,       0,       0,       0,       0,       0,
+                                       0,       0,       0,       0,       0,       0,       0,       0,   3.606,       0,       0,       0,       0,       0,       0,       0,       0,       0,  -3.606,       0,       0,
+                                       0,       0,       0,       0,       0,       0,       0,       0,       0,   3.606,       0,       0,       0,       0,       0,       0,       0,       0,       0,  -3.606,       0,
+                                       0,       0,       0,       0,       0,       0,       0,       0,       0,       0,  -0.043,       0,       0,       0,       0,       0,       0,       0,       0,       0,   0.043,
+                                 -1.8375,  10.542,  14.959,  19.376, -1.8375, -1.8375, -1.8375, -1.8375, -1.8375, -1.8375, -1.8375,  1.7082, -2.7086,  -7.126, -1.8375, -1.8375, -1.8375, -1.8375, -1.8375, -1.8375, -1.8375;
     sigma_point_deltas = mean_measurement.calculate_sigma_point_deltas<MyStateVector>(measurement_sigma_points);
 
     EXPECT_VECTOR_EQ(target_sigma_point_deltas.col(0),  sigma_point_deltas.col(0));
@@ -373,6 +408,7 @@ TEST(FixedMeasurementVectorTest, Innovation) {
     test_measurement.set_field<DynamicPressure>(0.5 * 122.5);
     test_measurement.set_field<Accelerometer>(UKF::Vector<3>(0, 0, 9.8));
     test_measurement.set_field<StaticPressure>(101.3);
+    test_measurement.set_field<Magnetometer>(UKF::FieldVector(0, 0.45, 0));
 
     MyStateVector::CovarianceMatrix covariance = MyStateVector::CovarianceMatrix::Zero();
     covariance.diagonal() << 1e-9, 1e-9, 1e-9, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0;
@@ -389,6 +425,7 @@ TEST(FixedMeasurementVectorTest, Innovation) {
     target_innovation.set_field<DynamicPressure>(0);
     target_innovation.set_field<Accelerometer>(UKF::Vector<3>(0, 0, 17.294));
     target_innovation.set_field<StaticPressure>(12.0);
+    target_innovation.set_field<Magnetometer>(UKF::FieldVector(0, 0, 2));
 
     EXPECT_VECTOR_EQ(target_innovation, mean_measurement.calculate_innovation(test_measurement));
 }
@@ -396,6 +433,8 @@ TEST(FixedMeasurementVectorTest, Innovation) {
 TEST(FixedMeasurementVectorTest, SigmaPointCovariance) {
     MyStateVector test_state;
     MyMeasurementVector test_measurement;
+
+    test_measurement.set_field<Magnetometer>(UKF::FieldVector(1, 0, 0));
 
     test_state.set_field<Velocity>(UKF::Vector<3>(1, 2, 3));
     test_state.set_field<AngularVelocity>(UKF::Vector<3>(1, 0, 0));
@@ -419,14 +458,17 @@ TEST(FixedMeasurementVectorTest, SigmaPointCovariance) {
 
     MyMeasurementVector::CovarianceMatrix expected_covariance;
 
-    expected_covariance << 5.31709,       0,       0,       0,       0,       0,       0,       0,
-                                 0, 5.31709,       0,       0,       0,       0,       0,       0,
-                                 0,       0, 29.2440,       0,       0,       0,       0,  -4.237,
-                                 0,       0,       0,       1,       0,       0,       0,       0,
-                                 0,       0,       0,       0,       1,       0,       0,       0,
-                                 0,       0,       0,       0,       0,       1,       0,       0,
-                                 0,       0,       0,       0,       0,       0, 1.44e-4,       0,
-                                 0,       0,  -4.237,       0,       0,       0,       0,  32.263;
+    expected_covariance << 5.31709,       0,       0,       0,       0,       0,       0, -2.3059,       0,       0,       0,
+                                 0, 5.31709,       0,       0,       0,       0,       0,       0,       0,       0,       0,
+                                 0,       0, 29.2440,       0,       0,       0,       0,       0,       0,       0,  -4.237,
+                                 0,       0,       0,       1,       0,       0,       0,       0,       0,       0,       0,
+                                 0,       0,       0,       0,       1,       0,       0,       0,       0,       0,       0,
+                                 0,       0,       0,       0,       0,       1,       0,       0,       0,       0,       0,
+                                 0,       0,       0,       0,       0,       0,       0,       0,       0,       0,       0,
+                           -2.3059,       0,       0,       0,       0,       0,       0,       1,       0,       0,       0,
+                                 0,       0,       0,       0,       0,       0,       0,       0,       1,       0,       0,
+                                 0,       0,       0,       0,       0,       0,       0,       0,       0, 1.44e-4,       0,
+                                 0,       0,  -4.237,       0,       0,       0,       0,       0,       0,       0,  32.263;
 
     EXPECT_VECTOR_EQ(expected_covariance.col(0),  calculated_covariance.col(0));
     EXPECT_VECTOR_EQ(expected_covariance.col(1),  calculated_covariance.col(1));
@@ -436,6 +478,9 @@ TEST(FixedMeasurementVectorTest, SigmaPointCovariance) {
     EXPECT_VECTOR_EQ(expected_covariance.col(5),  calculated_covariance.col(5));
     EXPECT_VECTOR_EQ(expected_covariance.col(6),  calculated_covariance.col(6));
     EXPECT_VECTOR_EQ(expected_covariance.col(7),  calculated_covariance.col(7));
+    EXPECT_VECTOR_EQ(expected_covariance.col(8),  calculated_covariance.col(8));
+    EXPECT_VECTOR_EQ(expected_covariance.col(9),  calculated_covariance.col(9));
+    EXPECT_VECTOR_EQ(expected_covariance.col(10),  calculated_covariance.col(10));
 }
 
 template <>
@@ -448,19 +493,25 @@ TEST(FixedMeasurementVectorTest, MeasurementCovariance) {
     MyMeasurementVector::measurement_covariance.set_field<DynamicPressure>(4);
     MyMeasurementVector::measurement_covariance.set_field<Accelerometer>(UKF::Vector<3>(5, 6, 7));
     MyMeasurementVector::measurement_covariance.set_field<StaticPressure>(8);
+    MyMeasurementVector::measurement_covariance.set_field<Magnetometer>(UKF::FieldVector(1, 2, 3));
 
     test_measurement.set_field<Gyroscope>(UKF::Vector<3>(0, 0, 0));
     test_measurement.set_field<DynamicPressure>(0);
     test_measurement.set_field<Accelerometer>(UKF::Vector<3>(0, 0, -9.8));
     test_measurement.set_field<StaticPressure>(101.3);
+    test_measurement.set_field<Magnetometer>(UKF::FieldVector(-1, 0, 1));
 
     expected_measurement.set_field<Gyroscope>(UKF::Vector<3>(0, 0, 0));
     expected_measurement.set_field<DynamicPressure>(0);
     expected_measurement.set_field<Accelerometer>(UKF::Vector<3>(0, 0, -9.8));
     expected_measurement.set_field<StaticPressure>(101.3);
+    expected_measurement.set_field<Magnetometer>(UKF::FieldVector(1, 1, 0));
 
     MyMeasurementVector::CovarianceMatrix expected_measurement_covariance = MyMeasurementVector::CovarianceMatrix::Zero();
-    expected_measurement_covariance.diagonal() << 5, 6, 7, 1, 2, 3, 8, 4;
+    expected_measurement_covariance.diagonal() << 5, 6, 7, 1, 2, 3, 0, 0, 0, 8, 4;
+    expected_measurement_covariance.block<3, 3>(6, 6) <<  8, -8,  0,
+                                                         -8,  8,  0,
+                                                          0,  0, 16;
 
     MyMeasurementVector::CovarianceMatrix measurement_covariance =
         test_measurement.calculate_measurement_covariance(expected_measurement);
@@ -473,6 +524,9 @@ TEST(FixedMeasurementVectorTest, MeasurementCovariance) {
     EXPECT_VECTOR_EQ(expected_measurement_covariance.col(5),  measurement_covariance.col(5));
     EXPECT_VECTOR_EQ(expected_measurement_covariance.col(6),  measurement_covariance.col(6));
     EXPECT_VECTOR_EQ(expected_measurement_covariance.col(7),  measurement_covariance.col(7));
+    EXPECT_VECTOR_EQ(expected_measurement_covariance.col(8),  measurement_covariance.col(8));
+    EXPECT_VECTOR_EQ(expected_measurement_covariance.col(9),  measurement_covariance.col(9));
+    EXPECT_VECTOR_EQ(expected_measurement_covariance.col(10),  measurement_covariance.col(10));
 }
 
 template <>
@@ -485,19 +539,25 @@ TEST(FixedMeasurementVectorTest, MeasurementRootCovariance) {
     MyMeasurementVector::measurement_root_covariance.set_field<DynamicPressure>(4);
     MyMeasurementVector::measurement_root_covariance.set_field<Accelerometer>(UKF::Vector<3>(5, 6, 7));
     MyMeasurementVector::measurement_root_covariance.set_field<StaticPressure>(8);
+    MyMeasurementVector::measurement_root_covariance.set_field<Magnetometer>(UKF::FieldVector(1, 2, 3));
 
     test_measurement.set_field<Gyroscope>(UKF::Vector<3>(0, 0, 0));
     test_measurement.set_field<DynamicPressure>(0);
     test_measurement.set_field<Accelerometer>(UKF::Vector<3>(0, 0, -9.8));
     test_measurement.set_field<StaticPressure>(101.3);
+    test_measurement.set_field<Magnetometer>(UKF::FieldVector(-1, 0, 1));
 
     expected_measurement.set_field<Gyroscope>(UKF::Vector<3>(0, 0, 0));
     expected_measurement.set_field<DynamicPressure>(0);
     expected_measurement.set_field<Accelerometer>(UKF::Vector<3>(0, 0, -9.8));
     expected_measurement.set_field<StaticPressure>(101.3);
+    expected_measurement.set_field<Magnetometer>(UKF::FieldVector(1, 1, 0));
 
     MyMeasurementVector::CovarianceMatrix expected_measurement_root_covariance = MyMeasurementVector::CovarianceMatrix::Zero();
-    expected_measurement_root_covariance.diagonal() << 5, 6, 7, 1, 2, 3, 8, 4;
+    expected_measurement_root_covariance.diagonal() << 5, 6, 7, 1, 2, 3, 0, 0, 0, 8, 4;
+    expected_measurement_root_covariance.block<3, 3>(6, 6) <<  0, -4,  0,
+                                                               0,  4,  0,
+                                                              -2,  0, -6;
 
     MyMeasurementVector::CovarianceMatrix measurement_root_covariance =
         test_measurement.calculate_measurement_root_covariance(expected_measurement);
@@ -510,6 +570,9 @@ TEST(FixedMeasurementVectorTest, MeasurementRootCovariance) {
     EXPECT_VECTOR_EQ(expected_measurement_root_covariance.col(5),  measurement_root_covariance.col(5));
     EXPECT_VECTOR_EQ(expected_measurement_root_covariance.col(6),  measurement_root_covariance.col(6));
     EXPECT_VECTOR_EQ(expected_measurement_root_covariance.col(7),  measurement_root_covariance.col(7));
+    EXPECT_VECTOR_EQ(expected_measurement_root_covariance.col(8),  measurement_root_covariance.col(8));
+    EXPECT_VECTOR_EQ(expected_measurement_root_covariance.col(9),  measurement_root_covariance.col(9));
+    EXPECT_VECTOR_EQ(expected_measurement_root_covariance.col(10),  measurement_root_covariance.col(10));
 }
 
 TEST(FixedMeasurementVectorTest, CalculateRotationVector) {

--- a/test/TestSquareRootCore.cpp
+++ b/test/TestSquareRootCore.cpp
@@ -78,7 +78,7 @@ using MyMeasurementVector = UKF::DynamicMeasurementVector<
     UKF::Field<GPS_Position, UKF::Vector<3>>,
     UKF::Field<GPS_Velocity, UKF::Vector<3>>,
     UKF::Field<Accelerometer, UKF::Vector<3>>,
-    UKF::Field<Magnetometer, UKF::Vector<3>>,
+    UKF::Field<Magnetometer, UKF::FieldVector>,
     UKF::Field<Gyroscope, UKF::Vector<3>>
 >;
 
@@ -111,9 +111,9 @@ UKF::Vector<3> MyMeasurementVector::expected_measurement
 }
 
 template <> template <>
-UKF::Vector<3> MyMeasurementVector::expected_measurement
+UKF::FieldVector MyMeasurementVector::expected_measurement
 <MyStateVector, Magnetometer>(const MyStateVector& state) {
-    return state.get_field<Attitude>() * UKF::Vector<3>(1, 0, 0);
+    return state.get_field<Attitude>() * UKF::FieldVector(1, 0, 0);
 }
 
 template <> template <>
@@ -150,10 +150,10 @@ UKF::Vector<3> MyMeasurementVector::expected_measurement
 }
 
 template <> template <>
-UKF::Vector<3> MyMeasurementVector::expected_measurement
+UKF::FieldVector MyMeasurementVector::expected_measurement
 <MyStateVector, Magnetometer, UKF::Vector<3>>(const MyStateVector& state,
         const UKF::Vector<3>& acceleration, const UKF::Vector<3>& angular_acceleration) {
-    return state.get_field<Attitude>() * UKF::Vector<3>(1, 0, 0);
+    return state.get_field<Attitude>() * UKF::FieldVector(1, 0, 0);
 }
 
 template <> template <>
@@ -251,7 +251,7 @@ TEST(SquareRootCoreTest, InnovationStep) {
     m.set_field<GPS_Position>(UKF::Vector<3>(100, 10, -50));
     m.set_field<GPS_Velocity>(UKF::Vector<3>(20, 0, 0));
     m.set_field<Accelerometer>(UKF::Vector<3>(0, 0, -9.8));
-    m.set_field<Magnetometer>(UKF::Vector<3>(0, -1, 0));
+    m.set_field<Magnetometer>(UKF::FieldVector(0, -1, 0));
     m.set_field<Gyroscope>(UKF::Vector<3>(0.5, 0, 0));
 
     test_filter.a_priori_step(0.01);
@@ -274,7 +274,7 @@ TEST(SquareRootCoreTest, InnovationStepPartialMeasurement) {
     MyMeasurementVector m;
 
     m.set_field<Accelerometer>(UKF::Vector<3>(0, 0, -9.8));
-    m.set_field<Magnetometer>(UKF::Vector<3>(0, -1, 0));
+    m.set_field<Magnetometer>(UKF::FieldVector(0, -1, 0));
     m.set_field<Gyroscope>(UKF::Vector<3>(0.5, 0, 0));
 
     test_filter.a_priori_step(0.01);
@@ -299,7 +299,7 @@ TEST(SquareRootCoreTest, InnovationStepWithInputs) {
     m.set_field<GPS_Position>(UKF::Vector<3>(100, 10, -50));
     m.set_field<GPS_Velocity>(UKF::Vector<3>(20, 0, 0));
     m.set_field<Accelerometer>(UKF::Vector<3>(0, 0, -15));
-    m.set_field<Magnetometer>(UKF::Vector<3>(0, -1, 0));
+    m.set_field<Magnetometer>(UKF::FieldVector(0, -1, 0));
     m.set_field<Gyroscope>(UKF::Vector<3>(0.5, 0, 0));
 
     test_filter.a_priori_step(0.01, UKF::Vector<3>(0, 0, -5), UKF::Vector<3>(1, 0, 0));
@@ -322,7 +322,7 @@ TEST(SquareRootCoreTest, InnovationStepPartialMeasurementWithInputs) {
     MyMeasurementVector m;
 
     m.set_field<Accelerometer>(UKF::Vector<3>(0, 0, -15));
-    m.set_field<Magnetometer>(UKF::Vector<3>(0, -1, 0));
+    m.set_field<Magnetometer>(UKF::FieldVector(0, -1, 0));
     m.set_field<Gyroscope>(UKF::Vector<3>(0.5, 0, 0));
 
     test_filter.a_priori_step(0.01, UKF::Vector<3>(0, 0, -5), UKF::Vector<3>(1, 0, 0));
@@ -347,7 +347,7 @@ TEST(SquareRootCoreTest, APosterioriStep) {
     m.set_field<GPS_Position>(UKF::Vector<3>(100, 10, -50));
     m.set_field<GPS_Velocity>(UKF::Vector<3>(20, 0, 0));
     m.set_field<Accelerometer>(UKF::Vector<3>(0, 0, -9.8));
-    m.set_field<Magnetometer>(UKF::Vector<3>(0, -1, 0));
+    m.set_field<Magnetometer>(UKF::FieldVector(0, -1, 0));
     m.set_field<Gyroscope>(UKF::Vector<3>(0.5, 0, 0));
 
     test_filter.a_priori_step(0.01);
@@ -371,7 +371,7 @@ TEST(SquareRootCoreTest, FullStep) {
     m.set_field<GPS_Position>(UKF::Vector<3>(100, 10, -50));
     m.set_field<GPS_Velocity>(UKF::Vector<3>(20, 0, 0));
     m.set_field<Accelerometer>(UKF::Vector<3>(0, 0, -14.8));
-    m.set_field<Magnetometer>(UKF::Vector<3>(0, -1, 0));
+    m.set_field<Magnetometer>(UKF::FieldVector(0, -1, 0));
     m.set_field<Gyroscope>(UKF::Vector<3>(0.5, 0, 0));
 
     test_filter.step(0.01, m, UKF::Vector<3>(0, 0, -5), UKF::Vector<3>(1, 0, 0));

--- a/test/TestSquareRootCore.cpp
+++ b/test/TestSquareRootCore.cpp
@@ -219,6 +219,7 @@ TEST(SquareRootCoreTest, APrioriStep) {
 
     test_filter.a_priori_step(0.01);
 
+    EXPECT_GT(test_filter.root_covariance.determinant(), std::numeric_limits<real_t>::epsilon());
     EXPECT_LT((UKF::Vector<3>(100, 10, -50) - test_filter.state.get_field<Position>()).norm(),
         test_filter.root_covariance.diagonal().segment<3>(0).norm()*2);
     EXPECT_LT((UKF::Vector<3>(20, 0, 0) - test_filter.state.get_field<Velocity>()).norm(),
@@ -234,6 +235,7 @@ TEST(SquareRootCoreTest, APrioriStepWithInputs) {
 
     test_filter.a_priori_step(0.01, UKF::Vector<3>(0, 0, -5), UKF::Vector<3>(1, 0, 0));
 
+    EXPECT_GT(test_filter.root_covariance.determinant(), std::numeric_limits<real_t>::epsilon());
     EXPECT_LT((UKF::Vector<3>(100, 10, -50) - test_filter.state.get_field<Position>()).norm(),
         test_filter.root_covariance.diagonal().segment<3>(0).norm()*2);
     EXPECT_LT((UKF::Vector<3>(20, 0, 0) - test_filter.state.get_field<Velocity>()).norm(),
@@ -257,8 +259,15 @@ TEST(SquareRootCoreTest, InnovationStep) {
     test_filter.a_priori_step(0.01);
     test_filter.innovation_step(m);
 
+    /*
+    With the field vector, we expect the determinant to be approximately zero,
+    so allow for it to be slightly negative due to numerical precision.
+    */
+    EXPECT_GE(test_filter.innovation_root_covariance.determinant(), -std::numeric_limits<real_t>::epsilon());
+
     test_filter.a_posteriori_step();
 
+    EXPECT_GT(test_filter.root_covariance.determinant(), std::numeric_limits<real_t>::epsilon());
     EXPECT_LT((UKF::Vector<3>(100, 10, -50) - test_filter.state.get_field<Position>()).norm(),
         test_filter.root_covariance.diagonal().segment<3>(0).norm()*2);
     EXPECT_LT((UKF::Vector<3>(20, 0, 0) - test_filter.state.get_field<Velocity>()).norm(),
@@ -280,8 +289,11 @@ TEST(SquareRootCoreTest, InnovationStepPartialMeasurement) {
     test_filter.a_priori_step(0.01);
     test_filter.innovation_step(m);
 
+    EXPECT_GE(test_filter.innovation_root_covariance.determinant(), -std::numeric_limits<real_t>::epsilon());
+
     test_filter.a_posteriori_step();
 
+    EXPECT_GT(test_filter.root_covariance.determinant(), std::numeric_limits<real_t>::epsilon());
     EXPECT_LT((UKF::Vector<3>(100, 10, -50) - test_filter.state.get_field<Position>()).norm(),
         test_filter.root_covariance.diagonal().segment<3>(0).norm()*2);
     EXPECT_LT((UKF::Vector<3>(20, 0, 0) - test_filter.state.get_field<Velocity>()).norm(),
@@ -305,8 +317,11 @@ TEST(SquareRootCoreTest, InnovationStepWithInputs) {
     test_filter.a_priori_step(0.01, UKF::Vector<3>(0, 0, -5), UKF::Vector<3>(1, 0, 0));
     test_filter.innovation_step(m, UKF::Vector<3>(0, 0, -5), UKF::Vector<3>(1, 0, 0));
 
+    EXPECT_GE(test_filter.innovation_root_covariance.determinant(), -std::numeric_limits<real_t>::epsilon());
+
     test_filter.a_posteriori_step();
 
+    EXPECT_GT(test_filter.root_covariance.determinant(), std::numeric_limits<real_t>::epsilon());
     EXPECT_LT((UKF::Vector<3>(100, 10, -50) - test_filter.state.get_field<Position>()).norm(),
         test_filter.root_covariance.diagonal().segment<3>(0).norm()*2);
     EXPECT_LT((UKF::Vector<3>(20, 0, 0) - test_filter.state.get_field<Velocity>()).norm(),
@@ -328,8 +343,11 @@ TEST(SquareRootCoreTest, InnovationStepPartialMeasurementWithInputs) {
     test_filter.a_priori_step(0.01, UKF::Vector<3>(0, 0, -5), UKF::Vector<3>(1, 0, 0));
     test_filter.innovation_step(m, UKF::Vector<3>(0, 0, -5), UKF::Vector<3>(1, 0, 0));
 
+    EXPECT_GE(test_filter.innovation_root_covariance.determinant(), -std::numeric_limits<real_t>::epsilon());
+
     test_filter.a_posteriori_step();
 
+    EXPECT_GT(test_filter.root_covariance.determinant(), std::numeric_limits<real_t>::epsilon());
     EXPECT_LT((UKF::Vector<3>(100, 10, -50) - test_filter.state.get_field<Position>()).norm(),
         test_filter.root_covariance.diagonal().segment<3>(0).norm()*2);
     EXPECT_LT((UKF::Vector<3>(20, 0, 0) - test_filter.state.get_field<Velocity>()).norm(),
@@ -354,6 +372,7 @@ TEST(SquareRootCoreTest, APosterioriStep) {
     test_filter.innovation_step(m);
     test_filter.a_posteriori_step();
 
+    EXPECT_GT(test_filter.root_covariance.determinant(), std::numeric_limits<real_t>::epsilon());
     EXPECT_LT((UKF::Vector<3>(100, 10, -50) - test_filter.state.get_field<Position>()).norm(),
         test_filter.root_covariance.diagonal().segment<3>(0).norm()*2);
     EXPECT_LT((UKF::Vector<3>(20, 0, 0) - test_filter.state.get_field<Velocity>()).norm(),
@@ -376,6 +395,7 @@ TEST(SquareRootCoreTest, FullStep) {
 
     test_filter.step(0.01, m, UKF::Vector<3>(0, 0, -5), UKF::Vector<3>(1, 0, 0));
 
+    EXPECT_GT(test_filter.root_covariance.determinant(), std::numeric_limits<real_t>::epsilon());
     EXPECT_LT((UKF::Vector<3>(100, 10, -50) - test_filter.state.get_field<Position>()).norm(),
         test_filter.root_covariance.diagonal().segment<3>(0).norm()*2);
     EXPECT_LT((UKF::Vector<3>(20, 0, 0) - test_filter.state.get_field<Velocity>()).norm(),


### PR DESCRIPTION
Some sensors (e.g. magnetometers) have an output which is 3-dimensional, but have only two degrees of freedom since their output is expected to be of a fixed magnitude. Including these in the measurement model as regular 3-vectors doesn't work very well at all since the assumption of a Gaussian distribution fails spectacularly.

This patch adds a specialised UKF::FieldVector type which is represented internally by rotation vectors, in order to correctly calculate the mean and covariance of the measurement sigma point distribution.

One of the implications of the reduction in degrees of freedom is that the resulting innovation covariance is always rank-deficient and therefore positive semi-definite. This required some changes to the filter to allow it to be dealt with properly; these changes should hopefully also make the filter more numerically stable in general.