### PR TITLE
Full-pivoting QR decomposition

### DIFF
--- a/include/UKF/Core.h
+++ b/include/UKF/Core.h
@@ -170,7 +170,7 @@ public:
         the inverse. This allows the innovation covariance to be positive semi-
         definite.
         */
-        CrossCorrelation kalman_gain = cross_correlation * innovation_covariance.fullPivHouseholderQr().solve(
+        CrossCorrelation kalman_gain = cross_correlation * innovation_covariance.colPivHouseholderQr().solve(
             MeasurementVectorType::CovarianceMatrix::Identity(innovation.size(), innovation.size()));
 
         /*

--- a/include/UKF/Core.h
+++ b/include/UKF/Core.h
@@ -170,7 +170,7 @@ public:
         the inverse. This allows the innovation covariance to be positive semi-
         definite.
         */
-        CrossCorrelation kalman_gain = cross_correlation * innovation_covariance.colPivHouseholderQr().solve(
+        CrossCorrelation kalman_gain = cross_correlation * innovation_covariance.fullPivHouseholderQr().solve(
             MeasurementVectorType::CovarianceMatrix::Identity(innovation.size(), innovation.size()));
 
         /*
@@ -375,8 +375,8 @@ public:
         literature. Eigen's QR decomposition implements a left-division,
         rather than the right-division assumed in the literature.
         */
-        CrossCorrelation kalman_gain = innovation_root_covariance.transpose().colPivHouseholderQr().solve(
-            innovation_root_covariance.colPivHouseholderQr().solve(
+        CrossCorrelation kalman_gain = innovation_root_covariance.transpose().fullPivHouseholderQr().solve(
+            innovation_root_covariance.fullPivHouseholderQr().solve(
                 cross_correlation.transpose())).transpose();
 
         /*
@@ -557,8 +557,8 @@ public:
         literature. Eigen's QR decomposition implements a left-division,
         rather than the right-division assumed in the literature.
         */
-        CrossCorrelation kalman_gain = innovation_root_covariance.transpose().colPivHouseholderQr().solve(
-            innovation_root_covariance.colPivHouseholderQr().solve(
+        CrossCorrelation kalman_gain = innovation_root_covariance.transpose().fullPivHouseholderQr().solve(
+            innovation_root_covariance.fullPivHouseholderQr().solve(
                 cross_correlation.transpose())).transpose();
 
         /*


### PR DESCRIPTION
Use full-pivoting QR decomposition in square root UKF for numerical stability when using rotation vectors in the measurement model.