### PR TITLE
Fixed a TODO in AHRS example

### DIFF
--- a/examples/ahrs/ahrs.cpp
+++ b/examples/ahrs/ahrs.cpp
@@ -104,30 +104,6 @@ using AHRS_MeasurementVector = UKF::DynamicMeasurementVector<
 
 namespace UKF {
 /*
-AHRS measurement model.
-TODO: Work out why we need to put the versions with no inputs arguments in.
-For some reason, if it's not there, we get a strange compilation eroor which
-seems to be the Detail::FieldTypes helper returning 'void' for everything.
-*/
-template <> template <>
-UKF::Vector<3> AHRS_MeasurementVector::expected_measurement
-<AHRS_StateVector, Accelerometer>(const AHRS_StateVector& state) {
-    return state.get_field<Attitude>() * UKF::Vector<3>(0, 0, -G_ACCEL);
-}
-
-template <> template <>
-UKF::Vector<3> AHRS_MeasurementVector::expected_measurement
-<AHRS_StateVector, Gyroscope>(const AHRS_StateVector& state) {
-    return state.get_field<AngularVelocity>();
-}
-
-template <> template <>
-UKF::Vector<3> AHRS_MeasurementVector::expected_measurement
-<AHRS_StateVector, Magnetometer>(const AHRS_StateVector& state) {
-    return state.get_field<Attitude>() * UKF::Vector<3>(MAG_NORM, 0, 0);
-}
-
-/*
 This is the measurement model that's actually used in the filter, because
 it's the one which takes the parameter estimation filter state as an input.
 */

--- a/include/UKF/StateVector.h
+++ b/include/UKF/StateVector.h
@@ -150,17 +150,27 @@ namespace UKF {
     };
 
     template <int Key, typename... Fields>
-    struct FieldTypes {
+    struct FieldTypesBase {
         using type = void;
     };
 
     template <int Key, typename T, typename... Fields>
-    struct FieldTypes<Key, T, Fields...> {
+    struct FieldTypesBase<Key, T, Fields...> {
         using type = typename IfHelper<
             Key == T::key,
             typename T::type,
-            typename FieldTypes<Key, Fields...>::type>::type;
+            typename FieldTypesBase<Key, Fields...>::type>::type;
     };
+
+    /*
+    A `boost::mpl::identity`-like wrapper to avoid inference errors when
+    specializing function templates.
+    In some situations when using FieldTypesBase directly only the primary
+    template gets resolved, resulting in failed substitutions.
+    This is solved in C++17, e.g. when compiling by GCC8
+    */
+    template <int Key, typename... Fields>
+    struct FieldTypes : FieldTypesBase<Key, Fields...> {};
 
     template <typename T>
     inline T convert_from_segment(const Vector<StateVectorDimension<T>>& state) {


### PR DESCRIPTION
Hey!
I was testing UKF offline for https://github.com/betaflight/betaflight BlackBox logs and while carving out the magnetometer noticed a TODO in `ahrs.cpp`.

It seems like for a variadic function template specialization only the primary template is used for deducing the return type. As a result it's always `void` or whatever is defined in the primary template.
I've found two ways around it - alias template or another level of indirection, e.g. not using `FieldTypes` directly but through a helper type which just uses `FieldTypes` internally (either inheriting it or defining a new alias.
This PR implements the second approach.

A similar trick is used in form of `boost::mpl::identity`, and C++17 seems to fix it (at least GCC-8 does).