### PR TITLE
change eigen download url

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ SET_DIRECTORY_PROPERTIES(PROPERTIES EP_PREFIX .)
 # Add eigen3.2.8
 ExternalProject_Add(
 eigen3
-URL https://bitbucket.org/eigen/eigen/get/3.2.8.tar.gz
+URL https://gitlab.com/libeigen/eigen/-/archive/3.2.8/eigen-3.2.8.tar.gz
 TIMEOUT 30
 # Apply the LLT malloc fix patch
 PATCH_COMMAND patch -p1 -t -N < ${PROJECT_SOURCE_DIR}/patch/eigen-3.2.8-no-malloc-in-llt.patch


### PR DESCRIPTION
Eigen repository migrated to gitlab on 4th December 2019.

http://eigen.tuxfamily.org/index.php?title=News:Migration_to_GitLab.com_scheduled_on_the_December_4th