### PR TITLE
Add DynamicMeasurementVector is_field_set method

### DIFF
--- a/include/UKF/MeasurementVector.h
+++ b/include/UKF/MeasurementVector.h
@@ -556,6 +556,17 @@ public:
     using CovarianceMatrix = MatrixDynamic<max_covariance_size(), max_covariance_size()>;
     using CovarianceVector = FixedMeasurementVector<Fields...>;
 
+    /* Test if an individual field is set. */
+    template <int Key>
+    bool is_field_set() const {
+        static_assert(Detail::get_field_size<Fields...>(Key) != std::numeric_limits<std::size_t>::max(),
+            "Specified key not present in measurement vector");
+
+        std::size_t offset = std::get<Detail::get_field_order<0, Fields...>(Key)>(field_offsets);
+
+        return (offset != std::numeric_limits<std::size_t>::max());
+    }
+
     /* Functions for accessing individual fields. */
     template <int Key>
     typename Detail::FieldTypes<Key, Fields...>::type get_field() const {


### PR DESCRIPTION
First of all, thank you very much for this great ukf library :+1: 

We have been using it at [Ecorobotix](https://ecorobotix.com/) in our sensor fusion software for more than one year and it gives excellent results on our machines AVO and ARA.

We heavily use `DynamicMeasurementVector` because our measurements are often partial (sensors are dynamically enabled/disabled and they publish at different frequencies).

In addition to existing methods `set_field<Key>()` and `get_field<Key>()`, it has been useful to add a method `is_field_set<Key>()` to know if a specific field is set for a given vector.