### PR TITLE
Allow direct process model

### DIFF
--- a/include/UKF/Integrator.h
+++ b/include/UKF/Integrator.h
@@ -27,6 +27,15 @@ SOFTWARE.
 
 namespace UKF {
 
+/* When we want a direct process model (avoid to integrate the process model derivative). */
+class NotUsedIntegrator {
+   public:
+    template <typename S, typename... U>
+    static S integrate(real_t delta, const S& state, const U&... input) {
+        throw std::runtime_error("NotUsedIntegrator is not supposed to be used");
+    }
+};
+
 /* Fourth-order integrator. */
 class IntegratorRK4 {
 public:

--- a/include/UKF/StateVector.h
+++ b/include/UKF/StateVector.h
@@ -428,6 +428,7 @@ public:
     This function calculates the derivative of the state vector. The
     derivative can be a function of the current state and any number of user-
     supplied non-state inputs.
+    It must be implemented if the core does not use "NotUsedIntegrator"
     */
     template <typename... U>
     StateVector derivative(const U&... input) const;
@@ -437,10 +438,17 @@ public:
     state based on the supplied time delta. This is achieved by using a
     numerical integrator and the derivative function.
     */
-    template <typename IntegratorType = IntegratorRK4, typename... U>
+    template <typename IntegratorType , typename... U>
     StateVector process_model(real_t delta, const U&... input) const {
         return IntegratorType::integrate(delta, *this, input...);
     }
+
+    /*
+    Apply the direct process model (without derivative).
+    It must be implemented if the core use "NotUsedIntegrator"
+    */
+    template <typename... U>
+    StateVector process_model(real_t delta, const U&... input) const;
 
     /* Update the state vector using a delta vector. */
     void apply_delta(const StateVectorDelta& delta) {


### PR DESCRIPTION
By reading your library, I guess it was practical for you to model your specific system by writing derivative formulas.

Then, you implemented `Integrator` classes to compute process model from the derivative model.

In our case, it was convenient to write the direct process model without writing explicit derivative formulas.

This PR consists of allowing to implement `StateVector::process_model()` method directly without needing to implement `StateVector::derivative()` method.