### PR TITLE
Add compiler test matrix support

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -26,7 +26,7 @@ jobs:
           - { os: ubuntu-20.04, CC: gcc-7, CXX: g++-7 }
           - { os: ubuntu-20.04, CC: clang-8, CXX: clang++-8 }
           - { os: ubuntu-20.04, CC: gcc-10, CXX: g++-10 }
-          - { os: ubuntu-20.04, CC: clang-13, CXX: clang++-13 }
+          - { os: ubuntu-20.04, CC: clang-12, CXX: clang++-12 }
           - { os: ubuntu-latest, CC: clang, CXX: clang++ }
           - { os: macOS-latest, CC: clang, CXX: clang++ }
           # - { os: windows-latest, CC: gcc, CXX: g++ }
@@ -37,7 +37,7 @@ jobs:
     - name: Install compiler
       run: |
          if [ "$RUNNER_OS" == "Linux" ]; then
-            sudo apt-get update && sudo apt-get install ${{ matrix.config.CC }} ${{ matrix.config.CXX }}
+          sudo apt-get update && sudo apt-get install ${{ matrix.config.CC }} ${{ matrix.config.CXX }}
          fi
       shell: bash
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -21,13 +21,15 @@ jobs:
       matrix:
         config:
           - { os: ubuntu-18.04, CC: gcc-7, CXX: g++-7 }
-          - { os: ubuntu-18.04, CC: clang-5, CXX: clang++-5 }
+          - { os: ubuntu-18.04, CC: clang-5.0, CXX: clang++-5.0 }
+          - { os: ubuntu-18.04, CC: clang-9, CXX: clang++-9 }
           - { os: ubuntu-20.04, CC: gcc-7, CXX: g++-7 }
           - { os: ubuntu-20.04, CC: clang-8, CXX: clang++-8 }
           - { os: ubuntu-20.04, CC: gcc-10, CXX: g++-10 }
-          - { os: ubuntu-20.04, CC: clang-10, CXX: clang++-10 }
+          - { os: ubuntu-20.04, CC: clang-13, CXX: clang++-13 }
+          - { os: ubuntu-latest, CC: clang, CXX: clang++ }
           - { os: macOS-latest, CC: clang, CXX: clang++ }
-          - { os: windows-latest, CC: gcc, CXX: g++ }
+          # - { os: windows-latest, CC: gcc, CXX: g++ }
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -20,8 +20,8 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - { os: ubuntu-16.04, CC: gcc-7, CXX: g++-7 }
-          - { os: ubuntu-16.04, CC: clang-5, CXX: clang++-5 }
+          - { os: ubuntu-18.04, CC: gcc-7, CXX: g++-7 }
+          - { os: ubuntu-18.04, CC: clang-5, CXX: clang++-5 }
           - { os: ubuntu-20.04, CC: gcc-7, CXX: g++-7 }
           - { os: ubuntu-20.04, CC: clang-8, CXX: clang++-8 }
           - { os: ubuntu-20.04, CC: gcc-10, CXX: g++-10 }
@@ -34,8 +34,8 @@ jobs:
     
     - name: Install compiler
       run: |
-         if ["$RUNNER_OS" == "Linux"]; then
-            sudo apt install ${{ matrix.config.CC }}
+         if [ "$RUNNER_OS" == "Linux" ]; then
+            sudo apt-get install ${{ matrix.config.CC }} ${{ matrix.config.CXX }}
          fi
       shell: bash
 
@@ -58,8 +58,7 @@ jobs:
       env:
         CC: ${{ matrix.config.CC }}
         CXX: ${{ matrix.config.CXX }}
-      working-directory: ${{github.workspace}}/build
       # Execute tests defined by the CMake configuration.  
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: make unittest && test/unittest
+      run: cd ${{github.workspace}}/build && make unittest && test/unittest
       

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -33,7 +33,7 @@ jobs:
     - uses: actions/checkout@v3
     
     - name: Install compiler
-    - run: |
+      run: |
          if ["$RUNNER_OS" == "Linux"]; then
             sudo apt install ${{ matrix.config.CC }}
          fi

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -27,7 +27,7 @@ jobs:
           - { os: ubuntu-20.04, CC: clang-8, CXX: clang++-8 }
           - { os: ubuntu-20.04, CC: gcc-10, CXX: g++-10 }
           - { os: ubuntu-20.04, CC: clang-12, CXX: clang++-12 }
-          - { os: ubuntu-latest, CC: clang, CXX: clang++ }
+          - { os: ubuntu-latest, CC: clang-14, CXX: clang++-14 }
           - { os: macOS-latest, CC: clang, CXX: clang++ }
           # - { os: windows-latest, CC: gcc, CXX: g++ }
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Install compiler
       run: |
          if [ "$RUNNER_OS" == "Linux" ]; then
-            sudo apt-get install ${{ matrix.config.CC }} ${{ matrix.config.CXX }}
+            sudo apt-get update && sudo apt-get install ${{ matrix.config.CC }} ${{ matrix.config.CXX }}
          fi
       shell: bash
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -15,21 +15,49 @@ jobs:
     # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
     # You can convert this to a matrix build if you need cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.config.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - { os: ubuntu-16.04, CC: gcc-7, CXX: g++-7 }
+          - { os: ubuntu-16.04, CC: clang-5, CXX: clang++-5 }
+          - { os: ubuntu-20.04, CC: gcc-7, CXX: g++-7 }
+          - { os: ubuntu-20.04, CC: clang-8, CXX: clang++-8 }
+          - { os: ubuntu-20.04, CC: gcc-10, CXX: g++-10 }
+          - { os: ubuntu-20.04, CC: clang-10, CXX: clang++-10 }
+          - { os: macOS-latest, CC: clang, CXX: clang++ }
+          - { os: windows-latest, CC: gcc, CXX: g++ }
 
     steps:
     - uses: actions/checkout@v3
+    
+    - name: Install compiler
+    - run: |
+         if ["$RUNNER_OS" == "Linux"]; then
+            sudo apt install ${{ matrix.config.CC }}
+         fi
+      shell: bash
 
     - name: Configure CMake
+      env:
+        CC: ${{ matrix.config.CC }}
+        CXX: ${{ matrix.config.CXX }}
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
       run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
 
     - name: Build
+      env:
+        CC: ${{ matrix.config.CC }}
+        CXX: ${{ matrix.config.CXX }}
       # Build your program with the given configuration
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
 
     - name: Test
+      env:
+        CC: ${{ matrix.config.CC }}
+        CXX: ${{ matrix.config.CXX }}
       working-directory: ${{github.workspace}}/build
       # Execute tests defined by the CMake configuration.  
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -27,7 +27,6 @@ jobs:
           - { os: ubuntu-20.04, CC: clang-8, CXX: clang++-8 }
           - { os: ubuntu-20.04, CC: gcc-10, CXX: g++-10 }
           - { os: ubuntu-20.04, CC: clang-12, CXX: clang++-12 }
-          - { os: ubuntu-latest, CC: clang-14, CXX: clang++-14 }
           - { os: macOS-latest, CC: clang, CXX: clang++ }
           # - { os: windows-latest, CC: gcc, CXX: g++ }
 


### PR DESCRIPTION
Builds and runs tests on the following environments/compilers:

* macOS latest with XCode latest
* ~~Windows latest with GCC~~ (needs some work)
* Ubuntu 18.04 LTS with GCC 7, Clang 5.0 and Clang 9
* Ubuntu 20.04 LTS with GCC 7, GCC 10, Clang 8, and Clang 12