### PR TITLE
Feature/sls 349 warnings as errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,48 +1,74 @@
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8.4 FATAL_ERROR)
-PROJECT(ukf)
-INCLUDE(ExternalProject)
-INCLUDE(CheckCXXCompilerFlag)
+cmake_minimum_required(VERSION 3.15)
+project(ukf)
+
+include(CheckCXXCompilerFlag)
+
+# Options for consumers / packagers
+option(UKF_USE_SYSTEM_EIGEN "Use system Eigen3 (via find_package) instead of downloading it" ON)
+option(UKF_DEFAULT_DOUBLE "Default to double precision for UKF (when not overridden by consumer)" ON)
+
+# Notes for maintainers:
+# - We prefer system Eigen by default to make packaging and editor tooling easier.
+# - When UKF_USE_SYSTEM_EIGEN=OFF we fall back to downloading Eigen 3.2.8 via
+#   ExternalProject (this preserves original upstream behavior while offering
+#   a reproducible fallback for environments without system Eigen).
 
 # Check for C++14 support.
 CHECK_CXX_COMPILER_FLAG("-std=c++14" COMPILER_SUPPORTS_CXX14)
-IF(COMPILER_SUPPORTS_CXX14)
-    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
-ELSE()
-    MESSAGE(STATUS "The compiler ${CMAKE_CXX_COMPILER} has no C++14 support. Please use a different C++ compiler.")
-ENDIF()
+if(COMPILER_SUPPORTS_CXX14)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
+else()
+    message(STATUS "The compiler ${CMAKE_CXX_COMPILER} has no C++14 support. Please use a different C++ compiler.")
+endif()
 
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-register -Wno-ignored-attributes")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-register -Wno-ignored-attributes")
 
-# Set default ExternalProject root directory
-SET_DIRECTORY_PROPERTIES(PROPERTIES EP_PREFIX .)
+# If requested prefer system Eigen (easier for packaging and editor tooling)
+if(UKF_USE_SYSTEM_EIGEN)
+    find_package(Eigen3 3.2 REQUIRED CONFIG)
+    set(eigen_dir ${EIGEN3_INCLUDE_DIR})
+else()
+    include(ExternalProject)
+    # Set default ExternalProject root directory
+    set_directory_properties(PROPERTIES EP_PREFIX .)
 
-# Add eigen3.2.8
-ExternalProject_Add(
-eigen3
-URL https://gitlab.com/libeigen/eigen/-/archive/3.2.8/eigen-3.2.8.tar.gz
-TIMEOUT 30
-# Apply the LLT malloc fix patch, necessary to avoid dynamic memory allocation on embedded systems.
-# This can be omitted on systems where dynamic memory allocation is acceptable.
-PATCH_COMMAND patch -p1 -t -N < ${PROJECT_SOURCE_DIR}/patch/eigen-3.2.8-no-malloc-in-llt.patch
-# Disable install step
-INSTALL_COMMAND ""
-# Wrap download, configure and build steps in a script to log output
-LOG_DOWNLOAD ON
-LOG_CONFIGURE ON
-LOG_BUILD ON)
+    # Add eigen3.2.8 as a fallback ExternalProject
+    ExternalProject_Add(
+        eigen3
+        URL https://gitlab.com/libeigen/eigen/-/archive/3.2.8/eigen-3.2.8.tar.gz
+        TIMEOUT 30
+        # Apply the LLT malloc fix patch, necessary to avoid dynamic memory allocation on embedded systems.
+        PATCH_COMMAND patch -p1 -t -N < ${PROJECT_SOURCE_DIR}/patch/eigen-3.2.8-no-malloc-in-llt.patch
+        # Disable install step
+        INSTALL_COMMAND ""
+        LOG_DOWNLOAD ON
+        LOG_CONFIGURE ON
+        LOG_BUILD ON)
 
-ExternalProject_Get_Property(eigen3 source_dir)
-SET(eigen_dir ${source_dir})
+    ExternalProject_Get_Property(eigen3 source_dir)
+    set(eigen_dir ${source_dir})
+endif()
 
-INCLUDE_DIRECTORIES(${eigen_dir})
+enable_testing()
 
-GET_DIRECTORY_PROPERTY(hasParent PARENT_DIRECTORY)
-IF(hasParent)
-    SET(eigen_dir ${eigen_dir} PARENT_SCOPE)
-ENDIF()
+add_subdirectory(test EXCLUDE_FROM_ALL)
+add_subdirectory(benchmark EXCLUDE_FROM_ALL)
+add_subdirectory(examples EXCLUDE_FROM_ALL)
 
-ENABLE_TESTING()
+# Create the INTERFACE target and provide include dirs and default compile defs
+add_library(ukf INTERFACE)
+target_include_directories(ukf INTERFACE
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+    ${eigen_dir}
+)
 
-ADD_SUBDIRECTORY(test EXCLUDE_FROM_ALL)
-ADD_SUBDIRECTORY(benchmark EXCLUDE_FROM_ALL)
-ADD_SUBDIRECTORY(examples EXCLUDE_FROM_ALL)
+if(UKF_DEFAULT_DOUBLE)
+    target_compile_definitions(ukf INTERFACE UKF_DOUBLE_PRECISION)
+else()
+    target_compile_definitions(ukf INTERFACE UKF_SINGLE_PRECISION)
+endif()
+
+# If system Eigen was used and the imported target exists, propagate it
+if(TARGET Eigen3::Eigen)
+    target_link_libraries(ukf INTERFACE Eigen3::Eigen)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,15 +12,10 @@ option(UKF_DEFAULT_DOUBLE "Default to double precision for UKF (when not overrid
 # - When UKF_USE_SYSTEM_EIGEN=OFF we fall back to downloading Eigen 3.2.8 via
 #   ExternalProject (this preserves original upstream behavior while offering
 #   a reproducible fallback for environments without system Eigen).
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-# Check for C++14 support.
-CHECK_CXX_COMPILER_FLAG("-std=c++14" COMPILER_SUPPORTS_CXX14)
-if(COMPILER_SUPPORTS_CXX14)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
-else()
-    message(STATUS "The compiler ${CMAKE_CXX_COMPILER} has no C++14 support. Please use a different C++ compiler.")
-endif()
-
+add_compile_options(-Wall -Wextra -Werror)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-register -Wno-ignored-attributes")
 
 # If requested prefer system Eigen (easier for packaging and editor tooling)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,48 @@
+# ukf (fork) — build and integration notes
+
+This is a small fork of the original `sfwa/ukf` library. The fork's CMake build has been adapted to make integration and editor tooling easier for downstream projects.
+
+New CMake options
+
+- `UKF_USE_SYSTEM_EIGEN` (BOOL, default: ON)
+  - If ON the build will use system-installed Eigen via `find_package(Eigen3)`.
+  - If OFF the project falls back to using an Embedded `ExternalProject` to download Eigen 3.2.8 (original behavior).
+
+- `UKF_DEFAULT_DOUBLE` (BOOL, default: ON)
+  - If ON the `ukf` INTERFACE target will propagate `UKF_DOUBLE_PRECISION`.
+  - If OFF the `ukf` INTERFACE target will propagate `UKF_SINGLE_PRECISION`.
+
+INTERFACE target
+
+- An `INTERFACE` target named `ukf` is provided. Consumers should link to it to get:
+  - the `ukf/include` directory in their include path,
+  - a propagated compile definition (`UKF_DOUBLE_PRECISION` or `UKF_SINGLE_PRECISION`), and
+  - Eigen transitively when `UKF_USE_SYSTEM_EIGEN` is ON and `Eigen3::Eigen` is available.
+
+Consumer examples
+
+Top-level CMake example (consumer):
+
+```cmake
+find_package(Eigen3 3.2 REQUIRED)
+add_subdirectory(path/to/ukf)
+
+add_executable(my_model src/my_model.cpp)
+target_link_libraries(my_model PRIVATE ukf Eigen3::Eigen)
+```
+
+Or let the `ukf` target export Eigen transitively:
+
+```cmake
+add_executable(my_model src/my_model.cpp)
+target_link_libraries(my_model PRIVATE ukf)
+```
+
+Notes and best practices
+
+- Prefer `UKF_USE_SYSTEM_EIGEN=ON` in development and CI to avoid the ExternalProject download step and to make editor tooling (clangd) pick up the system Eigen include paths.
+- If you change the default precision and want to force a different precision per-target use `target_compile_definitions(target PRIVATE UKF_SINGLE_PRECISION)` or `UKF_DOUBLE_PRECISION` as appropriate.
+
 # UKF
 
 Unscented Kalman filter library. Several different UKF implementations are

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -35,6 +35,12 @@ ADD_EXECUTABLE(benchmark
     SquareRootCoreBenchmark.cpp
     BenchmarkMain.cpp)
 
+# To avoid [-Werror=maybe-uninitialized] in file
+# /usr/include/eigen3/Eigen/Core:341
+target_compile_options(benchmark PRIVATE
+    -Wno-maybe-uninitialized
+)
+
 # Create dependency of benchmark on googlebenchmark
 ADD_DEPENDENCIES(benchmark googlebenchmark eigen3)
 

--- a/examples/sfwa_ukf/CMakeLists.txt
+++ b/examples/sfwa_ukf/CMakeLists.txt
@@ -9,4 +9,9 @@ INCLUDE_DIRECTORIES(../../include ${eigen_dir})
 cmake_policy(SET CMP0042 NEW)
 
 ADD_LIBRARY(sfwa_ukf SHARED cukf.cpp)
+# To avoid [-Werror=unused-parameter] and [-Werror-maybe-uninitialized]
+target_compile_options(sfwa_ukf PRIVATE
+    -Wno-unused-parameter
+    -Wno-maybe-uninitialized
+)
 SET_TARGET_PROPERTIES(sfwa_ukf PROPERTIES OUTPUT_NAME cukf)

--- a/include/UKF/MeasurementVector.h
+++ b/include/UKF/MeasurementVector.h
@@ -127,7 +127,7 @@ namespace UKF {
         */
         template <typename T>
         static Matrix<Detail::CovarianceDimension<T>, Detail::CovarianceDimension<T>> field_covariance(
-                const T& p, const T& z_pred, const T& z) {
+                const T& p, [[maybe_unused]] const T& z_pred, [[maybe_unused]] const T& z) {
             Matrix<Detail::CovarianceDimension<T>, Detail::CovarianceDimension<T>> temp =
                 Matrix<Detail::CovarianceDimension<T>, Detail::CovarianceDimension<T>>::Zero();
             temp.diagonal() << p;
@@ -147,7 +147,7 @@ namespace UKF {
 
         template <typename T>
         static Matrix<Detail::CovarianceDimension<T>, Detail::CovarianceDimension<T>> field_root_covariance(
-                const T& p, const T& z_pred, const T& z) {
+                const T& p, [[maybe_unused]] const T& z_pred, [[maybe_unused]] const T& z) {
             Matrix<Detail::CovarianceDimension<T>, Detail::CovarianceDimension<T>> temp =
                 Matrix<Detail::CovarianceDimension<T>, Detail::CovarianceDimension<T>>::Zero();
             temp.diagonal() << p;
@@ -177,12 +177,12 @@ namespace UKF {
         */
         template <typename T>
         static T sigma_point_mean(
-                const Matrix<Detail::StateVectorDimension<T>, S::num_sigma()>& sigma, const T& field) {
+                const Matrix<Detail::StateVectorDimension<T>, S::num_sigma()>& sigma, [[maybe_unused]] const T& field) {
             return Parameters::Sigma_WMI<S>*sigma.template block<Detail::StateVectorDimension<T>, S::num_sigma()-1>(
                 0, 1).rowwise().sum() + Parameters::Sigma_WM0<S>*sigma.col(0);
         }
 
-        static real_t sigma_point_mean(const Matrix<1, S::num_sigma()>& sigma, const real_t& field) {
+        static real_t sigma_point_mean(const Matrix<1, S::num_sigma()>& sigma, [[maybe_unused]] const real_t& field) {
             return Parameters::Sigma_WMI<S>*sigma.template segment<S::num_sigma()-1>(1).sum()
                 + Parameters::Sigma_WM0<S>*sigma(0);
         }
@@ -193,7 +193,7 @@ namespace UKF {
         set of sigma points. Then, calculate the mean of these rotations and
         apply it to the central sigma point.
         */
-        static FieldVector sigma_point_mean(const Matrix<3, S::num_sigma()>& sigma, const FieldVector& field) {
+        static FieldVector sigma_point_mean(const Matrix<3, S::num_sigma()>& sigma, [[maybe_unused]] const FieldVector& field) {
             Vector<3> temp = Vector<3>::Zero();
 
             for(std::size_t i = 0; i < S::num_sigma()-1; i++) {
@@ -590,7 +590,7 @@ public:
         std::size_t offset = std::get<Detail::get_field_order<0, Fields...>(Key)>(field_offsets);
 
         /* Check if this field has already been set. If so, replace it. */
-        if(offset < Base::size()) {
+        if(offset <static_cast<std::size_t>(Base::size())) {
             Base::template segment<Detail::get_field_size<Fields...>(Key)>(offset) << in;
         } else {
             /*

--- a/include/UKF/StateVector.h
+++ b/include/UKF/StateVector.h
@@ -528,12 +528,12 @@ private:
     The following algorithm implements equation (41d) from that paper.
     */
     template <typename T>
-    static T sigma_point_mean(const Matrix<Detail::StateVectorDimension<T>, num_sigma()>& sigma, const T& field) {
+    static T sigma_point_mean(const Matrix<Detail::StateVectorDimension<T>, num_sigma()>& sigma, [[maybe_unused]] const T& field) {
         return Parameters::Sigma_WMI<StateVector>*sigma.template block<Detail::StateVectorDimension<T>, num_sigma()-1>(
             0, 1).rowwise().sum() + Parameters::Sigma_WM0<StateVector>*sigma.col(0);
     }
 
-    static real_t sigma_point_mean(const Matrix<1, num_sigma()>& sigma, const real_t& field) {
+    static real_t sigma_point_mean(const Matrix<1, num_sigma()>& sigma, [[maybe_unused]] const real_t& field) {
         return Parameters::Sigma_WMI<StateVector>*sigma.template segment<num_sigma()-1>(1).sum()
             + Parameters::Sigma_WM0<StateVector>*sigma(0);
     }
@@ -543,7 +543,7 @@ private:
     this is not an ad-hoc renormalisation of an appoximation; see the paper
     mentioned above for details.
     */
-    static Vector<4> sigma_point_mean(const Matrix<4, num_sigma()>& sigma, const Quaternion& field) {
+    static Vector<4> sigma_point_mean(const Matrix<4, num_sigma()>& sigma, [[maybe_unused]] const Quaternion& field) {
         Vector<4> temp = Parameters::Sigma_WMI<StateVector>*sigma.template block<4, num_sigma()-1>(
             0, 1).rowwise().sum() + Parameters::Sigma_WM0<StateVector>*sigma.col(0);
         Quaternion temp_q = Quaternion(temp).normalized();

--- a/include/UKF/Types.h
+++ b/include/UKF/Types.h
@@ -23,8 +23,9 @@ SOFTWARE.
 #ifndef TYPES_H
 #define TYPES_H
 
-#include <Eigen/Core>
 #include "UKF/Config.h"
+#include <Eigen/Core>
+#include <Eigen/Geometry>
 
 namespace UKF {
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -35,6 +35,14 @@ ADD_EXECUTABLE(unittest
     TestCore.cpp
     TestSquareRootCore.cpp)
 
+# To avoid [-Werror=maybe-uninitialized] in file
+# /usr/include/eigen3/Eigen/Core:341
+# [-Werror=unused-parameter] in test code
+target_compile_options(unittest PRIVATE
+    -Wno-unused-parameter
+    -Wno-maybe-uninitialized
+)
+
 # Create dependency of test on googletest
 ADD_DEPENDENCIES(unittest googletest eigen3)
 

--- a/test/TestCore.cpp
+++ b/test/TestCore.cpp
@@ -130,35 +130,44 @@ calculated using the state vector and a dynamics model.
 template <> template <>
 UKF::Vector<3> MyMeasurementVector::expected_measurement
 <MyStateVector, GPS_Position>(const MyStateVector& state,
-        const UKF::Vector<3>& acceleration, const UKF::Vector<3>& angular_acceleration) {
+                              const UKF::Vector<3>& acceleration,
+                              const UKF::Vector<3>& angular_acceleration)
+{
     return state.get_field<Position>();
 }
 
 template <> template <>
 UKF::Vector<3> MyMeasurementVector::expected_measurement
 <MyStateVector, GPS_Velocity>(const MyStateVector& state,
-        const UKF::Vector<3>& acceleration, const UKF::Vector<3>& angular_acceleration) {
+                              const UKF::Vector<3>& acceleration,
+                              const UKF::Vector<3>& angular_acceleration)
+{
     return state.get_field<Velocity>();
 }
 
 template <> template <>
 UKF::Vector<3> MyMeasurementVector::expected_measurement
 <MyStateVector, Accelerometer, UKF::Vector<3>>(const MyStateVector& state,
-        const UKF::Vector<3>& acceleration, const UKF::Vector<3>& angular_acceleration) {
+        const UKF::Vector<3>& acceleration, const UKF::Vector<3>& angular_acceleration)
+{
     return state.get_field<Attitude>() * UKF::Vector<3>(0, 0, -9.8) + acceleration;
 }
 
 template <> template <>
 UKF::FieldVector MyMeasurementVector::expected_measurement
 <MyStateVector, Magnetometer, UKF::Vector<3>>(const MyStateVector& state,
-        const UKF::Vector<3>& acceleration, const UKF::Vector<3>& angular_acceleration) {
+                                              const UKF::Vector<3>& acceleration,
+                                              const UKF::Vector<3>& angular_acceleration)
+{
     return state.get_field<Attitude>() * UKF::FieldVector(1, 0, 0);
 }
 
 template <> template <>
 UKF::Vector<3> MyMeasurementVector::expected_measurement
 <MyStateVector, Gyroscope, UKF::Vector<3>>(const MyStateVector& state,
-        const UKF::Vector<3>& acceleration, const UKF::Vector<3>& angular_acceleration) {
+                                           const UKF::Vector<3>& acceleration,
+                                           const UKF::Vector<3>& angular_acceleration)
+{
     return state.get_field<AngularVelocity>();
 }
 
@@ -196,6 +205,7 @@ MyCore create_initialised_test_filter() {
 
 TEST(CoreTest, Initialisation) {
     MyCore test_filter = create_initialised_test_filter();
+    ASSERT_EQ(test_filter.state.size(), 13ul);
 }
 
 /*

--- a/test/TestDynamicMeasurementVector.cpp
+++ b/test/TestDynamicMeasurementVector.cpp
@@ -26,7 +26,7 @@ TEST(DynamicMeasurementVectorTest, Instantiation) {
     MyMeasurementVector test_measurement;
 
     EXPECT_EQ(11, MyMeasurementVector::MaxRowsAtCompileTime);
-    EXPECT_EQ(11, test_measurement.max_size());
+    EXPECT_EQ(11ul, test_measurement.max_size());
 }
 
 TEST(DynamicMeasurementVectorTest, Assignment) {

--- a/test/TestFixedMeasurementVector.cpp
+++ b/test/TestFixedMeasurementVector.cpp
@@ -26,7 +26,7 @@ TEST(FixedMeasurementVectorTest, Instantiation) {
     MyMeasurementVector test_measurement;
 
     EXPECT_EQ(11, MyMeasurementVector::MaxRowsAtCompileTime);
-    EXPECT_EQ(11, test_measurement.size());
+    EXPECT_EQ(11ul, test_measurement.size());
 }
 
 TEST(FixedMeasurementVectorTest, Assignment) {
@@ -38,7 +38,7 @@ TEST(FixedMeasurementVectorTest, Assignment) {
     test_measurement.set_field<StaticPressure>(8);
     test_measurement.set_field<Magnetometer>(UKF::FieldVector(9, 10, 11));
 
-    EXPECT_EQ(11, test_measurement.size());
+    EXPECT_EQ(11ul, test_measurement.size());
 
     EXPECT_EQ(8, test_measurement.get_field<StaticPressure>());
     EXPECT_EQ(4, test_measurement.get_field<DynamicPressure>());
@@ -60,12 +60,12 @@ TEST(FixedMeasurementVectorTest, Reassignment) {
     test_measurement.set_field<StaticPressure>(8);
     test_measurement.set_field<Magnetometer>(UKF::FieldVector(9, 10, 11));
 
-    EXPECT_EQ(11, test_measurement.size());
+    EXPECT_EQ(11ul, test_measurement.size());
     EXPECT_VECTOR_EQ(UKF::Vector<3>(1, 2, 3), test_measurement.get_field<Gyroscope>());
 
     test_measurement.set_field<Gyroscope>(UKF::Vector<3>(4, 5, 6));
 
-    EXPECT_EQ(11, test_measurement.size());
+    EXPECT_EQ(11ul, test_measurement.size());
     EXPECT_VECTOR_EQ(UKF::Vector<3>(4, 5, 6), test_measurement.get_field<Gyroscope>());
 
     UKF::Vector<11> expected;
@@ -82,42 +82,42 @@ TEST(FixedMeasurementVectorTest, MultipleReassignment) {
     test_measurement.set_field<StaticPressure>(8);
     test_measurement.set_field<Magnetometer>(UKF::FieldVector(9, 10, 11));
 
-    EXPECT_EQ(11, test_measurement.size());
+    EXPECT_EQ(11ul, test_measurement.size());
     UKF::Vector<11> expected;
     expected << 5, 6, 7, 1, 2, 3, 9, 10, 11, 8, 4;
     EXPECT_VECTOR_EQ(expected, test_measurement);
 
     test_measurement.set_field<Gyroscope>(UKF::Vector<3>(4, 5, 6));
 
-    EXPECT_EQ(11, test_measurement.size());
+    EXPECT_EQ(11ul, test_measurement.size());
     EXPECT_VECTOR_EQ(UKF::Vector<3>(4, 5, 6), test_measurement.get_field<Gyroscope>());
     expected << 5, 6, 7, 4, 5, 6, 9, 10, 11, 8, 4;
     EXPECT_VECTOR_EQ(expected, test_measurement);
 
     test_measurement.set_field<Accelerometer>(UKF::Vector<3>(7, 8, 9));
 
-    EXPECT_EQ(11, test_measurement.size());
+    EXPECT_EQ(11ul, test_measurement.size());
     EXPECT_VECTOR_EQ(UKF::Vector<3>(7, 8, 9), test_measurement.get_field<Accelerometer>());
     expected << 7, 8, 9, 4, 5, 6, 9, 10, 11, 8, 4;
     EXPECT_VECTOR_EQ(expected, test_measurement);
 
     test_measurement.set_field<DynamicPressure>(1);
 
-    EXPECT_EQ(11, test_measurement.size());
+    EXPECT_EQ(11ul, test_measurement.size());
     EXPECT_EQ(1, test_measurement.get_field<DynamicPressure>());
     expected << 7, 8, 9, 4, 5, 6, 9, 10, 11, 8, 1;
     EXPECT_VECTOR_EQ(expected, test_measurement);
 
     test_measurement.set_field<StaticPressure>(3);
 
-    EXPECT_EQ(11, test_measurement.size());
+    EXPECT_EQ(11ul, test_measurement.size());
     EXPECT_EQ(3, test_measurement.get_field<StaticPressure>());
     expected << 7, 8, 9, 4, 5, 6, 9, 10, 11, 3, 1;
     EXPECT_VECTOR_EQ(expected, test_measurement);
 
     test_measurement.set_field<Magnetometer>(UKF::FieldVector(1, 2, 3));
 
-    EXPECT_EQ(11, test_measurement.size());
+    EXPECT_EQ(11ul, test_measurement.size());
     EXPECT_VECTOR_EQ(UKF::Vector<3>(1, 2, 3), test_measurement.get_field<Magnetometer>());
     expected << 7, 8, 9, 4, 5, 6, 1, 2, 3, 3, 1;
     EXPECT_VECTOR_EQ(expected, test_measurement);

--- a/test/TestSquareRootCore.cpp
+++ b/test/TestSquareRootCore.cpp
@@ -138,14 +138,18 @@ calculated using the state vector and a dynamics model.
 template <> template <>
 UKF::Vector<3> MyMeasurementVector::expected_measurement
 <MyStateVector, GPS_Position>(const MyStateVector& state,
-        const UKF::Vector<3>& acceleration, const UKF::Vector<3>& angular_acceleration) {
+                              const UKF::Vector<3>& acceleration,
+                              const UKF::Vector<3>& angular_acceleration)
+{
     return state.get_field<Position>();
 }
 
 template <> template <>
 UKF::Vector<3> MyMeasurementVector::expected_measurement
 <MyStateVector, GPS_Velocity>(const MyStateVector& state,
-        const UKF::Vector<3>& acceleration, const UKF::Vector<3>& angular_acceleration) {
+                              const UKF::Vector<3>& acceleration,
+                              const UKF::Vector<3>& angular_acceleration)
+{
     return state.get_field<Velocity>();
 }
 
@@ -159,14 +163,18 @@ UKF::Vector<3> MyMeasurementVector::expected_measurement
 template <> template <>
 UKF::FieldVector MyMeasurementVector::expected_measurement
 <MyStateVector, Magnetometer, UKF::Vector<3>>(const MyStateVector& state,
-        const UKF::Vector<3>& acceleration, const UKF::Vector<3>& angular_acceleration) {
+                                              const UKF::Vector<3>& acceleration,
+                                              const UKF::Vector<3>& angular_acceleration)
+{
     return state.get_field<Attitude>() * UKF::FieldVector(1, 0, 0);
 }
 
 template <> template <>
 UKF::Vector<3> MyMeasurementVector::expected_measurement
 <MyStateVector, Gyroscope, UKF::Vector<3>>(const MyStateVector& state,
-        const UKF::Vector<3>& acceleration, const UKF::Vector<3>& angular_acceleration) {
+                                           const UKF::Vector<3>& acceleration,
+                                           const UKF::Vector<3>& angular_acceleration)
+{
     return state.get_field<AngularVelocity>();
 }
 
@@ -212,6 +220,7 @@ MyCore create_initialised_sr_test_filter() {
 
 TEST(SquareRootCoreTest, Initialisation) {
     MyCore test_filter = create_initialised_sr_test_filter();
+    ASSERT_EQ(test_filter.state.size(), 13ul);
 }
 
 /*

--- a/test/TestStateVector.cpp
+++ b/test/TestStateVector.cpp
@@ -27,7 +27,7 @@ TEST(StateVectorTest, Instantiation) {
     MyStateVector test_state;
 
     EXPECT_EQ(10, MyStateVector::MaxRowsAtCompileTime);
-    EXPECT_EQ(10, test_state.size());
+    EXPECT_EQ(10ul, test_state.size());
     EXPECT_EQ(9, MyStateVector::CovarianceMatrix::MaxRowsAtCompileTime);
     EXPECT_EQ(9, MyStateVector::CovarianceMatrix::MaxColsAtCompileTime);
     EXPECT_EQ(10, MyStateVector::SigmaPointDistribution::MaxRowsAtCompileTime);


### PR DESCRIPTION
Enable compiler flags to treat warnings as errors and adjusted code to be compliant. All *tests* now go passed.